### PR TITLE
ci: Add caching for Yarn and install via --frozen-lockfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs: # a collection of steps
             - ~/.cache/yarn
       - run: #run lint and check for formatting
           name: check
-          command: yarn sdk check
+          command: yarn sdk lint
       - run: #compile the code
           name: compile
           command: yarn sdk compile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,14 +7,16 @@ jobs: # a collection of steps
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
+          name: Restore Yarn Package Cache
+          key: yarn-packages-{{ checksum "yarn.lock" }}
       - run:
-          name: yarn install
-          command: yarn install
+          name: Install dependencies w/ Yarn
+          command: yarn install --frozen-lockfile
       - save_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
+          name: Save Yarn Package Cache
+          key: yarn-packages-{{ checksum "yarn.lock" }}
           paths:
-            - ./node_modules
+            - ~/.cache/yarn
       - run: #run lint and check for formatting
           name: check
           command: yarn sdk check

--- a/js-miniapp-sdk/package.json
+++ b/js-miniapp-sdk/package.json
@@ -24,11 +24,11 @@
     "typescript": "^3.8.3"
   },
   "scripts": {
-    "check": "gts check",
+    "lint": "gts check",
     "clean": "gts clean",
     "compile": "tsc -p .",
-    "prebuild": "npm run clean && npm run check",
-    "build": "npm run clean && npm run check && tsc -p . && npm run test",
+    "prebuild": "npm run clean && npm run lint",
+    "build": "npm run clean && npm run lint && tsc -p . && npm run test",
     "fix": "gts fix",
     "test": "mocha -r ts-node/register tests/**/*.spec.ts --reporter mocha-junit-reporter --reporter-options mochaFile=./test-results/mocha/results.xml",
     "coverage": "nyc npm test",


### PR DESCRIPTION
# Description
See https://circleci.com/docs/2.0/yarn/#caching.
Caching wasn't working correctly due to there no longer being a `packag-lock.json` file.
Also renamed the `check` NPM script to `lint` because `check` conflicts with one of Yarn's built-in comands.

# Checklist
- [ ] I wrote/updated tests for new/changed code
- [x] I ran `npm run build` without issues