### PR TITLE
build: Use 'node' module resolution for TS compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,6 @@ The repo is split into three packages:
 - `yarn sdk check`
 - `yarn sdk clean`
 - `yarn sdk compile`
-- `yarn sdk build`
+- `yarn sdk buildSdk`
 - `yarn sdk fix`
 - `yarn sdk test`

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "scripts": {
         "sdk": "yarn workspace js-miniapp-sdk",
         "sample": "yarn workspace js-miniapp-sample",
-        "bridge": "yarn workspace js-miniapp-bridge"
+        "bridge": "yarn workspace js-miniapp-bridge",
+        "postinstall": "yarn sdk compile"
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "strict": false,
     "target": "ES5",
     "lib": ["dom"],
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "moduleResolution": "node"
   }
 }


### PR DESCRIPTION
# Description
Module resolution wasn't working correctly when merging the changes for the sample app. See: https://www.typescriptlang.org/docs/handbook/module-resolution.html\#module-resolution-strategies

# Checklist
- [x] I wrote/updated tests for new/changed code
- [x] I ran `npm run build` without issues