### PR TITLE
GitHub publish release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,6 +117,18 @@ jobs: # a collection of steps
             else
               echo "Documentation not published for snapshot version"
             fi
+      - run:
+          name: Publish GitHub Release
+          command: |
+            set -e
+            curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
+            if [[ ! $CIRCLE_TAG == *"-"* ]]; then
+              echo "Publishing $CIRCLE_TAG release to GitHub"
+              ./bin/hub release create -a ./js-miniapp-sdk/build/miniapp.bundle.js -m $CIRCLE_TAG $CIRCLE_TAG
+            else
+              echo "Publishing $CIRCLE_TAG pre-release to GitHub"
+              ./bin/hub release create --prerelease -a ./js-miniapp-sdk/build/miniapp.bundle.js -m $CIRCLE_TAG $CIRCLE_TAG
+            fi
 
 workflows:
   version: 2

--- a/js-miniapp-sdk/package.json
+++ b/js-miniapp-sdk/package.json
@@ -2,8 +2,8 @@
   "name": "js-miniapp-sdk",
   "version": "0.1.0",
   "description": "Mini App SDK for JavaScript",
-  "main": "build/bundle.js",
-  "browser": "build/bundle.js",
+  "main": "build/miniapp.bundle.js",
+  "browser": "build/miniapp.bundle.js",
   "module": "build/src/index.js",
   "types": "build/src/index.d.ts",
   "dependencies": {},
@@ -33,7 +33,7 @@
   "scripts": {
     "lint": "gts check",
     "clean": "gts clean",
-    "compile": "tsc -p . && browserify ./build/src/index.js --standalone MiniApp > build/bundle.js ",
+    "compile": "tsc -p . && browserify ./build/src/index.js --standalone MiniApp > build/miniapp.bundle.js ",
     "prebuild": "npm run clean && npm run lint",
     "buildSdk": "npm run lint && npm run compile && npm run test",
     "fix": "gts fix",
@@ -47,7 +47,7 @@
     "LICENSE",
     "package.json",
     "build/src/",
-    "build/bundle.js"
+    "build/miniapp.bundle.js"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Description
Publish to GitHub releases after deployment. After running the publishing job, a release will be created on GitHub Releases tab which has the 'miniapp.bundle.js' attached. This is using GitHub's Hub CLI tool: https://github.com/github/hub.

# Checklist
- [x] I wrote/updated tests for new/changed code
- [x] I ran `npm run build` without issues