### PR TITLE
(bridge) Fix for Android 5 & 6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,30 @@ jobs: # a collection of steps
             - js-miniapp-sdk/build/
             - js-miniapp-sdk/publishableDocs/
 
+  build-bridge:
+    working_directory: ~/mini-js-bridge
+    docker:
+      - image: circleci/node:10.16.3
+    steps:
+      - checkout
+      - restore_cache:
+          name: Restore Yarn Package Cache
+          key: yarn-packages-{{ checksum "yarn.lock" }}
+      - run:
+          name: Install dependencies w/ Yarn
+          command: yarn install --frozen-lockfile
+      - save_cache:
+          name: Save Yarn Package Cache
+          key: yarn-packages-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/.cache/yarn
+      - run:
+          name: Test
+          command: yarn bridge test
+      - run:
+          name: Lint
+          command: yarn bridge lint
+
   build-sample: # builds  & tests the sample app against latest sdk build.
     working_directory: ~/js-miniapp-sample
     docker:
@@ -140,13 +164,8 @@ workflows:
               only: /^v.*/
             branches:
               only: /.*/
-      - build-sample:
-          filters:
-            tags:
-              # TODO: confirm
-              only: /.*/
-            branches:
-              only: /.*/
+      - build-bridge
+      - build-sample
       - sdk-release-verification:
           type: approval
           requires:

--- a/js-miniapp-bridge/.eslintrc.json
+++ b/js-miniapp-bridge/.eslintrc.json
@@ -1,0 +1,15 @@
+{
+    "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaVersion": 5
+    },
+    "env": { 
+        "es6": false,
+        "browser": true,
+        "node": true
+    },
+    "globals": {
+        "webkit": "readonly",
+        "Promise": "readonly"
+    }
+}

--- a/js-miniapp-bridge/package.json
+++ b/js-miniapp-bridge/package.json
@@ -10,6 +10,7 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^10.0.3",
     "chai": "^4.2.0",
+    "eslint": "^6.8.0",
     "gts": "^1.1.2",
     "jsdom": "16.2.2",
     "jsdom-global": "3.0.2",
@@ -22,6 +23,7 @@
   },
   "scripts": {
     "test": "mocha -r jsdom-global/register -r ts-node/register tests/**/*.spec.js --reporter mocha-junit-reporter --reporter-options mochaFile=./test-results/mocha/results.xml",
+    "lint": "eslint src/ --fix-dry-run",
     "coverage": "nyc npm test"
   },
   "repository": {

--- a/js-miniapp-bridge/src/bridge.js
+++ b/js-miniapp-bridge/src/bridge.js
@@ -19,7 +19,7 @@ var isPlatform = {
  * @param  {[Function]} onError Error callback function
  */
 MiniAppBridge.exec = function(action, onSuccess, onError) {
-  const callback = {};
+  var callback = {};
   callback.onSuccess = onSuccess;
   callback.onError = onError;
   callback.id = String(++uniqueId);
@@ -43,9 +43,9 @@ MiniAppBridge.exec = function(action, onSuccess, onError) {
  * @param  {[String]} value Response value sent from the native on invoking the action command
  */
 MiniAppBridge.execSuccessCallback = function(messageId, value) {
-  var queueObj = MiniAppBridge.messageQueue.find(
-    (callback) => (callback.id = messageId)
-  );
+  var queueObj = MiniAppBridge.messageQueue.filter(
+    function(callback) { return callback.id == messageId }
+  )[0];
   if (value) {
     queueObj.onSuccess(value);
   } else {
@@ -62,9 +62,9 @@ MiniAppBridge.execSuccessCallback = function(messageId, value) {
  * @param  {[String]} errorMessage Error message sent from the native on invoking the action command
  */
 MiniAppBridge.execErrorCallback = function(messageId, errorMessage) {
-  var queueObj = MiniAppBridge.messageQueue.find(
-    (callback) => (callback.id = messageId)
-  );
+  var queueObj = MiniAppBridge.messageQueue.filter(
+    function(callback) { return callback.id == messageId }
+  )[0];
   if (!errorMessage) {
     errorMessage = "Unknown Error";
   }
@@ -88,13 +88,17 @@ function removeFromMessageQueue(queueObj) {
  * Associating getUniqueId function to MiniAppBridge object
  */
 MiniAppBridge.getUniqueId = function() {
-  return new Promise((resolve, reject) => {
+  return new Promise(function(resolve, reject) {
     return MiniAppBridge.exec(
       "getUniqueId",
-      (id) => resolve(id),
-      (error) => reject(error)
+      function(id) { return resolve(id) },
+      function (error) { return reject(error) }
     );
   });
 };
 window.MiniAppBridge = MiniAppBridge;
-module.exports = MiniAppBridge;
+
+// Exported for unit testing
+if (typeof exports==="object" && typeof module!=="undefined") {
+  module.exports = MiniAppBridge;
+}


### PR DESCRIPTION
# Description
Some JS features were unsupported on older browsers. The bridge script was not working on Android 5 and 6 because the default install of Chrome is a very outdated version. This means our bridge script needs to use features which target ES5. This commit replaces arrow functions (=>) with normal functions and replaces 'Array.find' with 'Array.filter'. Also moved the 'module.exports' to an 'if' statement to avoid errors in the browser.

Also added CircleCI job for bridge and setup linting with recommended settings and using es5 to ensure we don't use unsupported features

# Checklist
- [x] I wrote/updated tests for new/changed code
- [x] I ran `npm run build` without issues