### PR TITLE
Fixes for doc publishing from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,11 +128,10 @@ jobs: # a collection of steps
           name: Publish Documentation
           command: |
             set -e
-            yarn sdk docs
             if [[ ! $CIRCLE_TAG == *"-"* ]]; then
               git checkout gh-pages
               cp -R publishableDocs/docs/. ./docs
-              cp -R publishableDocs/_versions. ./_versions
+              cp -R publishableDocs/_versions/. ./_versions
               git add docs _versions
               git config user.name "CI Publisher"
               git config user.email "dev-opensource@mail.rakuten.com"

--- a/js-miniapp-sdk/scripts/docs.sh
+++ b/js-miniapp-sdk/scripts/docs.sh
@@ -22,3 +22,6 @@ npx typedoc --includeVersion --out $DIR_DOCS/api src --plugin typedoc-plugin-mar
 # Move userguide to docs and create correct folder structure
 mv $DIR_DOCS/api/README.md $DIR_DOCS/api/index.md
 cp README.md $DIR_DOCS/index.md
+# The typedoc plugin generates breadcrumbs which point to `README.md` as the parent page
+# So we must create this page and add a redirect to `index`
+cp ./scripts/readme-redirect.md $DIR_DOCS/api/README.md

--- a/js-miniapp-sdk/scripts/docs.sh
+++ b/js-miniapp-sdk/scripts/docs.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-PACKAGE_VERSION=$(node -p "require('./package.json').version")
+
+# Get SDK version as X.X (remove fix version)
+PACKAGE_VERSION=$(node -p "require('./package.json').version" | sed -e 's/\.[0-9]*$//')
 echo "version: $PACKAGE_VERSION"
 
 DIR_DOCS="publishableDocs/docs/$PACKAGE_VERSION"

--- a/js-miniapp-sdk/scripts/docs.sh
+++ b/js-miniapp-sdk/scripts/docs.sh
@@ -16,6 +16,9 @@ version: "$PACKAGE_VERSION"
 ---"
 cat <<< "$contents" > "$FILE_VERSION_MD"
 
-npx typedoc --includeVersion --out $DIR_DOCS/api src --plugin typedoc-plugin-markdown --stripInternal --readme none
+# Generate docs
+npx typedoc --includeVersion --out $DIR_DOCS/api src --plugin typedoc-plugin-markdown --stripInternal --readme none --mode file
+
+# Move userguide to docs and create correct folder structure
 mv $DIR_DOCS/api/README.md $DIR_DOCS/api/index.md
 cp README.md $DIR_DOCS/index.md

--- a/js-miniapp-sdk/scripts/readme-redirect.md
+++ b/js-miniapp-sdk/scripts/readme-redirect.md
@@ -1,0 +1,11 @@
+---
+layout: default
+---
+
+<!-- Redirects to `index.html` from `README.html` -->
+<html>
+    <head>
+        <meta http-equiv="refresh" content="0;url=./index.html" />
+    </head>
+    <body></body>
+</html>

--- a/js-miniapp-sdk/src/index.ts
+++ b/js-miniapp-sdk/src/index.ts
@@ -6,6 +6,7 @@
 
 import { MiniAppImp } from './miniapp';
 
+/** @internal */
 const miniAppInstance = new MiniAppImp();
 
 export = miniAppInstance;


### PR DESCRIPTION
# Description
- Publish docs as X.X without fix version. Docs should be published as X.X so if a new fix version is published, it will replace the documentation for the previous version. However, publishing a new minor version will still create new a docs version

-  Change typedoc to 'file' mode instead of 'module'. The module mode causes issues with Github pages because it uses underscores in the filenames i.e. '_index_.html'. Github pages treats files that start with an underscore as hidden, so these pages were showing as 404.

- Fix breadcrumb parent link. Typedoc generates the parent link as 'README.md', but we are using 'index.md'. Typedoc doesn't have any options to easily change this (except hiding breadcrumbs), so I've added a 'README.md' wh
ich just redirects to index.

# Checklist
- [x] I wrote/updated tests for new/changed code
- [x] I ran `npm run build` without issues