### PR TITLE
Fix docs for v1.0.0 on gh-pages

### DIFF
--- a/docs/1.0/api/README.md
+++ b/docs/1.0/api/README.md
@@ -1,0 +1,11 @@
+---
+layout: default
+---
+
+<!-- Redirects to `index.html` from `README.html` -->
+<html>
+    <head>
+        <meta http-equiv="refresh" content="0;url=./index.html" />
+    </head>
+    <body></body>
+</html>

--- a/docs/1.0/api/index.md
+++ b/docs/1.0/api/index.md
@@ -4,6 +4,6 @@
 
 ## Index
 
-### Modules
+### Interfaces
 
-* ["miniapp"](modules/_miniapp_.md)
+* [MiniApp](interfaces/miniapp.md)

--- a/docs/1.0/api/interfaces/miniapp.md
+++ b/docs/1.0/api/interfaces/miniapp.md
@@ -1,4 +1,4 @@
-[js-miniapp-sdk - v1.0.0](../README.md) › ["miniapp"](../modules/_miniapp_.md) › [MiniApp](_miniapp_.miniapp.md)
+[js-miniapp-sdk - v1.0.0](../README.md) › [MiniApp](miniapp.md)
 
 # Interface: MiniApp
 
@@ -12,7 +12,7 @@ A module layer for webapps and mobile native interaction.
 
 ### Methods
 
-* [getUniqueId](_miniapp_.miniapp.md#getuniqueid)
+* [getUniqueId](miniapp.md#getuniqueid)
 
 ## Methods
 

--- a/docs/1.0/api/modules/_miniapp_.md
+++ b/docs/1.0/api/modules/_miniapp_.md
@@ -1,9 +1,0 @@
-[js-miniapp-sdk - v1.0.0](../README.md) › ["miniapp"](_miniapp_.md)
-
-# Module: "miniapp"
-
-## Index
-
-### Interfaces
-
-* [MiniApp](../interfaces/_miniapp_.miniapp.md)


### PR DESCRIPTION
# Description
There were some issues with the previously published docs because Github Pages won't render files that start with an underscore, so most of the API pages were showing 404. Also fixed the link to the parent page in the breadcrumbs

# Checklist
- [ ] I wrote/updated tests for new/changed code
- [x] I ran `npm run build` without issues