### PR TITLE
Add Landing Page for MiniApp Sample for Js-SDK

### DIFF
--- a/js-miniapp-sample/src/components/GreyCard.js
+++ b/js-miniapp-sample/src/components/GreyCard.js
@@ -20,9 +20,7 @@ type CardType = {
 const GreyCard = (props: CardType) => {
   const classes = useStyles(props);
   return (
-    <Card
-      className={`${classes.root} ${props.className || ''}`}
-    >
+    <Card className={`${classes.root} ${props.className || ''}`}>
       {props.children}
     </Card>
   );

--- a/js-miniapp-sample/src/components/GreyCard.js
+++ b/js-miniapp-sample/src/components/GreyCard.js
@@ -1,0 +1,29 @@
+import * as React from "react";
+
+import {Card, makeStyles} from "@material-ui/core";
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    background: theme.color.secondary,
+    height: props => props.height || 300,
+    maxWidth: 500,
+    width: '95%',
+  },
+}));
+
+type CardType = {
+  height?: number | string,
+  children: React.Node,
+  className?: string
+}
+
+const GreyCard = (props: CardType) => {
+  const classes = useStyles(props);
+  return (
+    <Card className={`${classes.root} ${props.className ? props.className : ''}`}>
+      {props.children}
+    </Card>
+  );
+}
+
+export default GreyCard;

--- a/js-miniapp-sample/src/components/GreyCard.js
+++ b/js-miniapp-sample/src/components/GreyCard.js
@@ -1,11 +1,11 @@
-import * as React from "react";
+import * as React from 'react';
 
-import {Card, makeStyles} from "@material-ui/core";
+import { Card, makeStyles } from '@material-ui/core';
 
 const useStyles = makeStyles((theme) => ({
   root: {
     background: theme.color.secondary,
-    height: props => props.height || 300,
+    height: (props) => props.height || 300,
     maxWidth: 500,
     width: '95%',
   },
@@ -14,16 +14,18 @@ const useStyles = makeStyles((theme) => ({
 type CardType = {
   height?: number | string,
   children: React.Node,
-  className?: string
-}
+  className?: string,
+};
 
 const GreyCard = (props: CardType) => {
   const classes = useStyles(props);
   return (
-    <Card className={`${classes.root} ${props.className ? props.className : ''}`}>
+    <Card
+      className={`${classes.root} ${props.className ? props.className : ''}`}
+    >
       {props.children}
     </Card>
   );
-}
+};
 
 export default GreyCard;

--- a/js-miniapp-sample/src/components/GreyCard.js
+++ b/js-miniapp-sample/src/components/GreyCard.js
@@ -21,7 +21,7 @@ const GreyCard = (props: CardType) => {
   const classes = useStyles(props);
   return (
     <Card
-      className={`${classes.root} ${props.className ? props.className : ''}`}
+      className={`${classes.root} ${props.className || ''}`}
     >
       {props.children}
     </Card>

--- a/js-miniapp-sample/src/pages/auth-token.js
+++ b/js-miniapp-sample/src/pages/auth-token.js
@@ -8,20 +8,15 @@ import {
   Grid,
   Typography,
   CardContent,
-  Card,
 } from '@material-ui/core';
 import { red, green } from '@material-ui/core/colors';
 import { makeStyles } from '@material-ui/core/styles';
 import axios from 'axios';
 import clsx from 'clsx';
 
+import GreyCard from '../components/GreyCard';
+
 const useStyles = makeStyles((theme) => ({
-  root: {
-    background: theme.color.secondary,
-    width: '85vw',
-    maxWidth: 500,
-    marginTop: 15,
-  },
   wrapper: {
     position: 'relative',
     marginTop: 20,
@@ -166,7 +161,7 @@ function AuthToken() {
   }
 
   return (
-    <Card className={classes.root}>
+    <GreyCard height="auto">
       <CardContent>
         <FormGroup column="true" classes={{ root: classes.rootFormGroup }}>
           <Typography variant="body2" align="center">
@@ -195,7 +190,7 @@ function AuthToken() {
           )}
         </FormGroup>
       </CardContent>
-    </Card>
+    </GreyCard>
   );
 }
 

--- a/js-miniapp-sample/src/pages/chatbot.js
+++ b/js-miniapp-sample/src/pages/chatbot.js
@@ -6,7 +6,6 @@ import {
   InputLabel,
   Select,
   MenuItem,
-  Card,
   CardContent,
   CardActions,
   Button,
@@ -21,6 +20,7 @@ import { connect } from 'react-redux';
 
 import { getBotsList } from '../services/chatbot/actions';
 import type { ChatBot } from '../services/chatbot/types';
+import GreyCard from '../components/GreyCard';
 
 const useStyles = makeStyles((theme) => ({
   formControl: {
@@ -32,12 +32,6 @@ const useStyles = makeStyles((theme) => ({
     '& div': {
       color: theme.color.primary,
     },
-  },
-  root: {
-    background: theme.color.secondary,
-    height: 300,
-    maxWidth: 500,
-    width: '95%',
   },
   content: {
     height: '50%',
@@ -108,7 +102,7 @@ const TalkToChatBot = (props: ChatBotProps) => {
   };
   return (
     <Fragment>
-      <Card className={classes.root}>
+      <GreyCard>
         <CardContent className={classes.content}>
           <FormControl className={classes.formControl}>
             <InputLabel id="chatbotLabel">Chatbot</InputLabel>
@@ -158,7 +152,7 @@ const TalkToChatBot = (props: ChatBotProps) => {
             SEND MESSAGE
           </Button>
         </CardActions>
-      </Card>
+      </GreyCard>
 
       <Dialog
         data-testid="chatbot-response-dialog"

--- a/js-miniapp-sample/src/pages/fetch-credentials.js
+++ b/js-miniapp-sample/src/pages/fetch-credentials.js
@@ -8,20 +8,15 @@ import {
   Grid,
   Typography,
   CardContent,
-  Card,
 } from '@material-ui/core';
 import { red, green } from '@material-ui/core/colors';
 import { makeStyles } from '@material-ui/core/styles';
 import axios from 'axios';
 import clsx from 'clsx';
 
+import GreyCard from '../components/GreyCard';
+
 const useStyles = makeStyles((theme) => ({
-  root: {
-    background: theme.color.secondary,
-    width: '85vw',
-    maxWidth: 500,
-    marginTop: 15,
-  },
   wrapper: {
     position: 'relative',
     marginTop: 20,
@@ -180,7 +175,7 @@ function FetchCredentials() {
   }
 
   return (
-    <Card className={classes.root}>
+    <GreyCard height="auto">
       <CardContent>
         <FormGroup column="true" classes={{ root: classes.rootFormGroup }}>
           <Typography variant="body2" align="center">
@@ -209,7 +204,7 @@ function FetchCredentials() {
           )}
         </FormGroup>
       </CardContent>
-    </Card>
+    </GreyCard>
   );
 }
 

--- a/js-miniapp-sample/src/pages/landing.js
+++ b/js-miniapp-sample/src/pages/landing.js
@@ -1,5 +1,5 @@
-import React from "react";
-import {Card, CardContent, makeStyles } from "@material-ui/core";
+import React from 'react';
+import { Card, CardContent, makeStyles } from '@material-ui/core';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -7,9 +7,9 @@ const useStyles = makeStyles((theme) => ({
     height: 300,
     maxWidth: 500,
     width: '95%',
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center"
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   content: {
     height: '25%',
@@ -21,8 +21,8 @@ const useStyles = makeStyles((theme) => ({
     color: theme.color.primary,
     fontWeight: 'bold',
     '& p': {
-      lineHeight: 1.5
-    }
+      lineHeight: 1.5,
+    },
   },
 }));
 
@@ -35,6 +35,6 @@ const Landing = () => {
       </CardContent>
     </Card>
   );
-}
+};
 
 export default Landing;

--- a/js-miniapp-sample/src/pages/landing.js
+++ b/js-miniapp-sample/src/pages/landing.js
@@ -1,12 +1,10 @@
 import React from 'react';
-import { Card, CardContent, makeStyles } from '@material-ui/core';
+import { CardContent, makeStyles } from '@material-ui/core';
+
+import GreyCard from '../components/GreyCard';
 
 const useStyles = makeStyles((theme) => ({
-  root: {
-    background: theme.color.secondary,
-    height: 300,
-    maxWidth: 500,
-    width: '95%',
+  card: {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
@@ -29,11 +27,11 @@ const useStyles = makeStyles((theme) => ({
 const Landing = () => {
   const classes = useStyles();
   return (
-    <Card className={classes.root}>
+    <GreyCard className={classes.card}>
       <CardContent className={classes.content}>
         <p>This is a Demo App of Mini App JS SDK</p>
       </CardContent>
-    </Card>
+    </GreyCard>
   );
 };
 

--- a/js-miniapp-sample/src/pages/landing.js
+++ b/js-miniapp-sample/src/pages/landing.js
@@ -1,0 +1,40 @@
+import React from "react";
+import {Card, CardContent, makeStyles } from "@material-ui/core";
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    background: theme.color.secondary,
+    height: 300,
+    maxWidth: 500,
+    width: '95%',
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center"
+  },
+  content: {
+    height: '25%',
+    justifyContent: 'center',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    fontSize: 18,
+    color: theme.color.primary,
+    fontWeight: 'bold',
+    '& p': {
+      lineHeight: 1.5
+    }
+  },
+}));
+
+const Landing = () => {
+  const classes = useStyles();
+  return (
+    <Card className={classes.root}>
+      <CardContent className={classes.content}>
+        <p>This is a Demo App of Mini App JS SDK</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default Landing;

--- a/js-miniapp-sample/src/pages/local-storage.js
+++ b/js-miniapp-sample/src/pages/local-storage.js
@@ -4,20 +4,14 @@ import {
   Button,
   TextField,
   makeStyles,
-  Card,
   CardContent,
   CardActions,
 } from '@material-ui/core';
 
+import GreyCard from '../components/GreyCard';
 import useLocalStorage from '../hooks/useLocalStorage';
 
 const useStyles = makeStyles((theme) => ({
-  root: {
-    background: theme.color.secondary,
-    height: 300,
-    maxWidth: 500,
-    width: '95%',
-  },
   content: {
     height: '25%',
     justifyContent: 'center',
@@ -68,7 +62,7 @@ function LocalStorage() {
   };
 
   return (
-    <Card className={classes.root}>
+    <GreyCard>
       <CardContent className={classes.content}>
         <TextField
           type="text"
@@ -100,7 +94,7 @@ function LocalStorage() {
           Save text to Local Storage
         </Button>
       </CardActions>
-    </Card>
+    </GreyCard>
   );
 }
 

--- a/js-miniapp-sample/src/pages/tests/landing.test.js
+++ b/js-miniapp-sample/src/pages/tests/landing.test.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+import Landing from '../landing';
+import {wrapTheme} from "../../tests/test-utils";
+
+test('Landing text is rendered', () => {
+  render(wrapTheme(<Landing/>));
+  expect(screen.getByText('This is a Demo App of Mini App JS SDK')).toBeInTheDocument();
+});

--- a/js-miniapp-sample/src/pages/user-details.js
+++ b/js-miniapp-sample/src/pages/user-details.js
@@ -5,7 +5,6 @@ import {
   CircularProgress,
   FormGroup,
   Typography,
-  Card,
   CardContent,
   CardActions,
   TextField,
@@ -17,6 +16,8 @@ import { red, green } from '@material-ui/core/colors';
 import { makeStyles } from '@material-ui/core/styles';
 import axios from 'axios';
 import clsx from 'clsx';
+
+import GreyCard from '../components/GreyCard';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -299,7 +300,7 @@ function UserDetails() {
   }
 
   return (
-    <Card className={classes.root}>
+    <GreyCard height="auto">
       <CardContent>
         <Typography variant="body2" align="center">
           Please note that we use a <strong>mocked API</strong> in this example
@@ -313,7 +314,7 @@ function UserDetails() {
       <CardActions classes={{ root: classes.rootCardActions }}>
         {CardActionsForm()}
       </CardActions>
-    </Card>
+    </GreyCard>
   );
 }
 

--- a/js-miniapp-sample/src/pages/uuid_sdk.js
+++ b/js-miniapp-sample/src/pages/uuid_sdk.js
@@ -2,22 +2,16 @@ import React from 'react';
 
 import {
   Button,
-  Card,
   CardContent,
   CardActions,
   makeStyles,
 } from '@material-ui/core';
 import { connect } from 'react-redux';
 
+import GreyCard from '../components/GreyCard';
 import { setUUID } from '../services/uuid/actions';
 
 const useStyles = makeStyles((theme) => ({
-  root: {
-    background: theme.color.secondary,
-    height: 300,
-    maxWidth: 500,
-    width: '95%',
-  },
   content: {
     height: '50%',
     justifyContent: 'center',
@@ -44,7 +38,7 @@ type UUIDProps = {
 const UuidFetcher = (props: UUIDProps) => {
   const classes = useStyles();
   return (
-    <Card className={classes.root}>
+    <GreyCard>
       <CardContent className={classes.content}>
         {props.uuid ?? 'Not Available'}
       </CardContent>
@@ -59,7 +53,7 @@ const UuidFetcher = (props: UUIDProps) => {
           GET UNIQUE ID
         </Button>
       </CardActions>
-    </Card>
+    </GreyCard>
   );
 };
 

--- a/js-miniapp-sample/src/pages/web_location.js
+++ b/js-miniapp-sample/src/pages/web_location.js
@@ -2,7 +2,6 @@ import React from 'react';
 
 import {
   Button,
-  Card,
   CardActions,
   CardContent,
   makeStyles,
@@ -11,15 +10,10 @@ import LocationOffIcon from '@material-ui/icons/LocationOff';
 import LocationSearchingIcon from '@material-ui/icons/LocationSearching';
 import clsx from 'clsx';
 
+import GreyCard from '../components/GreyCard';
 import useGeoLocation from '../hooks/useGeoLocation';
 
 const useStyles = makeStyles((theme) => ({
-  root: {
-    background: theme.color.secondary,
-    height: 300,
-    maxWidth: 500,
-    width: '95%',
-  },
   content: {
     height: '50%',
     justifyContent: 'center',
@@ -63,7 +57,7 @@ const Location = (props: any) => {
   const [state, watch, unwatch] = useGeoLocation();
 
   return (
-    <Card className={classes.root}>
+    <GreyCard>
       <CardContent className={classes.content}>
         {state.location && state.isWatching && (
           <div
@@ -109,7 +103,7 @@ const Location = (props: any) => {
           TURN OFF
         </Button>
       </CardActions>
-    </Card>
+    </GreyCard>
   );
 };
 

--- a/js-miniapp-sample/src/routes.js
+++ b/js-miniapp-sample/src/routes.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 import ChatIcon from '@material-ui/icons/Chat';
 import FingerprintIcon from '@material-ui/icons/Fingerprint';
+import HomeIcon from '@material-ui/icons/Home';
 import LocationOnIcon from '@material-ui/icons/LocationOn';
 import LockOpenIcon from '@material-ui/icons/LockOpen';
 import PersonIcon from '@material-ui/icons/Person';
@@ -11,12 +12,19 @@ import VpnKeyIcon from '@material-ui/icons/VpnKey';
 import AuthToken from './pages/auth-token';
 import TalkToChatBot from './pages/chatbot';
 import FetchCredentials from './pages/fetch-credentials';
+import Landing from "./pages/landing";
 import LocalStorage from './pages/local-storage';
 import UserDetails from './pages/user-details';
 import UuidFetcher from './pages/uuid_sdk';
 import WebLocation from './pages/web_location';
 
 const navItems = [
+  {
+    icon: <HomeIcon />,
+    label: 'Home',
+    navLink: '/landing',
+    component: Landing,
+  },
   {
     icon: <StorageIcon />,
     label: 'Local Storage',


### PR DESCRIPTION
# Description
Added a new landing page that shows: This is a Demo App of Mini App JS SDK
Added a new generic GreyCard component that can be extended using the same MaterialUI syntax

## Links
https://jira.rakuten-it.com/jira/browse/MINIBUILD-159

# Checklist
- [x] I ran `yarn sample test` without issues
- [x] I ran `yarn sample flow` without issues