### PR TITLE
ci: Fix documentation publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,8 +130,8 @@ jobs: # a collection of steps
             set -e
             if [[ ! $CIRCLE_TAG == *"-"* ]]; then
               git checkout gh-pages
-              cp -R publishableDocs/docs/. ./docs
-              cp -R publishableDocs/_versions/. ./_versions
+              cp -R ./js-miniapp-sdk/publishableDocs/docs/. ./docs
+              cp -R ./js-miniapp-sdk/publishableDocs/_versions/. ./_versions
               git add docs _versions
               git config user.name "CI Publisher"
               git config user.email "dev-opensource@mail.rakuten.com"


### PR DESCRIPTION
# Description
There was an incorrect path in the 'Publish Documentation' step when copying the docs from generated folder

# Checklist
- [x] I wrote/updated tests for new/changed code
- [x] I ran `npm run build` without issues