### PR TITLE
bridge: add custom permission function in common bridge

### DIFF
--- a/js-miniapp-bridge/src/common-bridge.ts
+++ b/js-miniapp-bridge/src/common-bridge.ts
@@ -102,7 +102,7 @@ export class MiniAppBridge {
 
   /**
    * Associating requestCustomPermissions function to MiniAppBridge object
-   * @param string[] permissionTypes, Type of custom permissions that is requested
+   * @param [string, string] permissionTypes, Type of custom permissions that is requested
    * using an Array including the parameters eg. name, description.
    *
    * Miniapps should use "rakuten.miniapp.user." prefix for a valid name of the custom permissions

--- a/js-miniapp-bridge/src/common-bridge.ts
+++ b/js-miniapp-bridge/src/common-bridge.ts
@@ -103,6 +103,7 @@ export class MiniAppBridge {
   /**
    * Associating requestCustomPermissions function to MiniAppBridge object
    * @param {string[]} permissionTypes, Array of type of custom permissions that is requested
+   * For eg., user name, profile photo, contact list.
    */
   requestCustomPermissions(permissionTypes: string[]) {
     return new Promise<string>((resolve, reject) => {

--- a/js-miniapp-bridge/src/common-bridge.ts
+++ b/js-miniapp-bridge/src/common-bridge.ts
@@ -87,13 +87,29 @@ export class MiniAppBridge {
 
   /**
    * Associating requestPermission function to MiniAppBridge object
-   * @param {String} permissionType Type of permission that is requested. For eg., location
+   * @param {string} permissionType Type of permission that is requested. For eg., location
    */
   requestPermission(permissionType: string) {
     return new Promise<string>((resolve, reject) => {
       return this.executor.exec(
         'requestPermission',
         { permission: permissionType },
+        success => resolve(success),
+        error => reject(error)
+      );
+    });
+  }
+
+  /**
+   * Associating requestCustomPermissions function to MiniAppBridge object
+   * @param {string[]} permissionTypes, Array includes type of custom permissions that is requested. 
+   * For eg., user name, profile photo, contact list
+   */
+  requestCustomPermissions(permissionTypes: string[]) {
+    return new Promise<string>((resolve, reject) => {
+      return this.executor.exec(
+        'requestCustomPermissions',
+        { permissions: permissionTypes },
         success => resolve(success),
         error => reject(error)
       );

--- a/js-miniapp-bridge/src/common-bridge.ts
+++ b/js-miniapp-bridge/src/common-bridge.ts
@@ -102,8 +102,7 @@ export class MiniAppBridge {
 
   /**
    * Associating requestCustomPermissions function to MiniAppBridge object
-   * @param {string[]} permissionTypes, Array includes type of custom permissions that is requested. 
-   * For eg., user name, profile photo, contact list
+   * @param {string[]} permissionTypes, Array of type of custom permissions that is requested
    */
   requestCustomPermissions(permissionTypes: string[]) {
     return new Promise<string>((resolve, reject) => {

--- a/js-miniapp-bridge/src/common-bridge.ts
+++ b/js-miniapp-bridge/src/common-bridge.ts
@@ -118,7 +118,7 @@ export class MiniAppBridge {
    *  {"name":"any unknown name", "description": "Reason to request for the custom permission"}
    * ]
    */
-  requestCustomPermissions(permissionTypes: string[]) {
+  requestCustomPermissions(permissionTypes: [string, string]) {
     return new Promise<string>((resolve, reject) => {
       return this.executor.exec(
         'requestCustomPermissions',

--- a/js-miniapp-bridge/src/common-bridge.ts
+++ b/js-miniapp-bridge/src/common-bridge.ts
@@ -27,6 +27,11 @@ export interface PlatformExecutor {
   ): void;
 }
 
+export interface CustomPermission {
+  name: string;
+  description: string;
+}
+
 export class MiniAppBridge {
   executor: PlatformExecutor;
 
@@ -102,23 +107,17 @@ export class MiniAppBridge {
 
   /**
    * Associating requestCustomPermissions function to MiniAppBridge object
-   * @param [string, string] permissionTypes, Type of custom permissions that is requested
+   * @param [CustomPermission[] permissionTypes, Types of custom permissions that are requested
    * using an Array including the parameters eg. name, description.
    *
-   * Miniapps should use "rakuten.miniapp.user." prefix for a valid name of the custom permissions
    * For eg., Miniapps can pass the array of valid custom permissions as following
    * [
    *  {"name":"rakuten.miniapp.user.USER_NAME", "description": "Reason to request for the custom permission"},
    *  {"name":"rakuten.miniapp.user.PROFILE_PHOTO", "description": "Reason to request for the custom permission"},
    *  {"name":"rakuten.miniapp.user.CONTACT_LIST", "description": "Reason to request for the custom permission"}
    * ]
-   *
-   * For eg., Miniapps can pass the array of invalid custom permissions as following
-   * [
-   *  {"name":"any unknown name", "description": "Reason to request for the custom permission"}
-   * ]
    */
-  requestCustomPermissions(permissionTypes: [string, string]) {
+  requestCustomPermissions(permissionTypes: CustomPermission[]) {
     return new Promise<string>((resolve, reject) => {
       return this.executor.exec(
         'requestCustomPermissions',

--- a/js-miniapp-bridge/src/common-bridge.ts
+++ b/js-miniapp-bridge/src/common-bridge.ts
@@ -102,8 +102,21 @@ export class MiniAppBridge {
 
   /**
    * Associating requestCustomPermissions function to MiniAppBridge object
-   * @param {string[]} permissionTypes, Array of type of custom permissions that is requested
-   * For eg., user name, profile photo, contact list.
+   * @param string[] permissionTypes, Type of custom permissions that is requested
+   * using an Array including the parameters eg. name, description.
+   *
+   * Miniapps should use "rakuten.miniapp.user." prefix for a valid name of the custom permissions
+   * For eg., Miniapps can pass the array of valid custom permissions as following
+   * [
+   *  {"name":"rakuten.miniapp.user.USER_NAME", "description": "Reason to request for the custom permission"},
+   *  {"name":"rakuten.miniapp.user.PROFILE_PHOTO", "description": "Reason to request for the custom permission"},
+   *  {"name":"rakuten.miniapp.user.CONTACT_LIST", "description": "Reason to request for the custom permission"}
+   * ]
+   *
+   * For eg., Miniapps can pass the array of invalid custom permissions as following
+   * [
+   *  {"name":"any unknown name", "description": "Reason to request for the custom permission"}
+   * ]
    */
   requestCustomPermissions(permissionTypes: string[]) {
     return new Promise<string>((resolve, reject) => {


### PR DESCRIPTION
# Description
Add `requestCustomPermissions` function in `common-bridge.ts` to ask for the custom permissions from miniapps to Android, iOS or Native.

# Jira
[MINI-959](https://jira.rakuten-it.com/jira/browse/MINI-959)

# Checklist
- [ ] I wrote/updated tests for new/changed code.
- [x] I ran `yarn sdk buildSdk` and `yarn bridge buildBridge` without issues.
- [x] I ran `yarn sample prettify` and `yarn sample build` without issues.