### PR TITLE
fix: (bridge) Parse json response on request permissions

### DIFF
--- a/js-miniapp-bridge/src/common-bridge.ts
+++ b/js-miniapp-bridge/src/common-bridge.ts
@@ -187,7 +187,7 @@ export class MiniAppBridge {
       return this.executor.exec(
         'requestCustomPermissions',
         { permissions: permissionTypes },
-        success => resolve(success),
+        success => resolve(JSON.parse(success)),
         error => reject(error)
       );
     });


### PR DESCRIPTION
# Description
The iOS/Android side returns a string so this must be first parsed before it can be used. 
Also did some refactoring of the bridge tests to reduce duplication.

## Links
MINI-1586

# Checklist
- [x] I wrote/updated tests for new/changed code.
- [x] I ran `yarn sdk buildSdk` and `yarn bridge buildBridge` without issues.
- [x] I ran `yarn sample prettify` and `yarn sample build` without issues.
