### PR TITLE
test: error handle for custom permission

### DIFF
--- a/js-miniapp-bridge/test/test.spec.ts
+++ b/js-miniapp-bridge/test/test.spec.ts
@@ -17,6 +17,8 @@ const mockExecutor = {
   getPlatform: sinon.stub(),
 };
 
+const handleError = error => {};
+
 beforeEach(() => {
   sandbox.restore();
 });
@@ -107,7 +109,7 @@ describe('requestCustomPermissions', () => {
   it('will call the platform executor', () => {
     const bridge = new Bridge.MiniAppBridge(mockExecutor);
 
-    bridge.requestCustomPermissions(requestPermissions);
+    bridge.requestCustomPermissions(requestPermissions).catch(handleError);
 
     sinon.assert.calledWith(mockExecutor.exec, 'requestCustomPermissions');
   });
@@ -115,7 +117,7 @@ describe('requestCustomPermissions', () => {
   it('will attach the permissions to the `permissions` key', () => {
     const bridge = new Bridge.MiniAppBridge(mockExecutor);
 
-    bridge.requestCustomPermissions(requestPermissions);
+    bridge.requestCustomPermissions(requestPermissions).catch(handleError);
 
     sinon.assert.calledWith(mockExecutor.exec, sinon.match.any, {
       permissions: requestPermissions,


### PR DESCRIPTION
# Description
The test cases of custom permission pass but there is long error log warning. This PR solves that issue.

# Checklist
- [x] I wrote/updated tests for new/changed code.
- [x] I ran `yarn sdk buildSdk` and `yarn bridge buildBridge` without issues.
- [x] I ran `yarn sample prettify` and `yarn sample build` without issues.
