### PR TITLE
build: (sample) Add script to create ZIP file of build assets

### DIFF
--- a/js-miniapp-sample/package.json
+++ b/js-miniapp-sample/package.json
@@ -22,11 +22,13 @@
     "prettify": "prettier --config ./prettier.config.js --check src/**/*.js",
     "lint": "eslint src/ --fix-dry-run",
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "react-scripts build && npm run zip",
     "dockerBuild": "cd ci && make build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "flow": "flow"
+    "flow": "flow",
+    "deleteUnsupportedBuildFiles": "(cd build; find . -type f -name \"*.txt\" -delete -o -name \".DS_Store\" -delete)",
+    "zip": "(npm run deleteUnsupportedBuildFiles; cd build; zip -r js-miniapp-sample.zip ./*)"
   },
   "browserslist": [
     ">0.2%",


### PR DESCRIPTION
# Description
The script will run everytime that the build script is run. Also deletes txt files as these are unsupported by the backend

# Checklist
- [x] I wrote/updated tests for new/changed code.
- [x] I ran `yarn sdk buildSdk` and `yarn bridge buildBridge` without issues.
- [x] I ran `yarn sample prettify` and `yarn sample build` without issues.
