### PR TITLE
feat: add location permission to custom permissions management

### DIFF
--- a/js-miniapp-bridge/src/types/custom-permissions.ts
+++ b/js-miniapp-bridge/src/types/custom-permissions.ts
@@ -2,6 +2,7 @@ export enum CustomPermissionName {
   USER_NAME = 'rakuten.miniapp.user.USER_NAME',
   PROFILE_PHOTO = 'rakuten.miniapp.user.PROFILE_PHOTO',
   CONTACT_LIST = 'rakuten.miniapp.user.CONTACT_LIST',
+  LOCATION = 'rakuten.miniapp.device.LOCATION'
 }
 
 export enum CustomPermissionStatus {

--- a/js-miniapp-bridge/src/types/custom-permissions.ts
+++ b/js-miniapp-bridge/src/types/custom-permissions.ts
@@ -2,7 +2,7 @@ export enum CustomPermissionName {
   USER_NAME = 'rakuten.miniapp.user.USER_NAME',
   PROFILE_PHOTO = 'rakuten.miniapp.user.PROFILE_PHOTO',
   CONTACT_LIST = 'rakuten.miniapp.user.CONTACT_LIST',
-  LOCATION = 'rakuten.miniapp.device.LOCATION'
+  LOCATION = 'rakuten.miniapp.device.LOCATION',
 }
 
 export enum CustomPermissionStatus {

--- a/js-miniapp-sample/src/hooks/useGeoLocation.js
+++ b/js-miniapp-sample/src/hooks/useGeoLocation.js
@@ -7,7 +7,7 @@ const useGeoLocation = () => {
     isWatching: false,
   });
   const watch = () => {
-    return MiniApp.requestLocationPermission()
+    return MiniApp.requestLocationPermission('We would like to display the location of your device.')
       .then(() =>
         navigator.geolocation.getCurrentPosition(
           (pos) => {

--- a/js-miniapp-sample/src/hooks/useGeoLocation.js
+++ b/js-miniapp-sample/src/hooks/useGeoLocation.js
@@ -7,7 +7,9 @@ const useGeoLocation = () => {
     isWatching: false,
   });
   const watch = () => {
-    return MiniApp.requestLocationPermission('We would like to display the location of your device.')
+    return MiniApp.requestLocationPermission(
+      'We would like to display the location of your device.'
+    )
       .then(() =>
         navigator.geolocation.getCurrentPosition(
           (pos) => {

--- a/js-miniapp-sdk/CHANGELOG.md
+++ b/js-miniapp-sdk/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### In Progress (2020-XX-XX)
 - **Feature:** Added `CustomPermissionName.LOCATION`.
-- **Change:** Updated `requestLocationPermission()`` to `requestLocationPermission(permissionDescription?: string)`. From now `requestLocationPermission` will request both custom and device permission respectively.
+- **Change:** Updated `requestLocationPermission()` to `requestLocationPermission(permissionDescription?: string)`. From now `requestLocationPermission` will request both custom and device permission respectively.
 
 ### 1.5.0 (2020-11-13)
 

--- a/js-miniapp-sdk/CHANGELOG.md
+++ b/js-miniapp-sdk/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### In Progress (2020-XX-XX)
 - **Feature:** Added `CustomPermissionName.LOCATION`.
-- **Change:** Updated `requestLocationPermission()`` to `requestLocationPermission(permissionDescription: string)`. From now `requestLocationPermission` will request both custom and device permission respectively.
+- **Change:** Updated `requestLocationPermission()`` to `requestLocationPermission(permissionDescription?: string)`. From now `requestLocationPermission` will request both custom and device permission respectively.
 
 ### 1.5.0 (2020-11-13)
 

--- a/js-miniapp-sdk/CHANGELOG.md
+++ b/js-miniapp-sdk/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### In Progress (2020-XX-XX)
 - **Feature:** Added `CustomPermissionName.LOCATION`.
-- **Change:** Updated `requestLocationPermission()`` to `requestLocationPermission(description?: string)`. From now `requestLocationPermission` will request both custom and device permission respectively.
+- **Change:** Updated `requestLocationPermission()`` to `requestLocationPermission(permissionDescription: string)`. From now `requestLocationPermission` will request both custom and device permission respectively.
 
 ### 1.5.0 (2020-11-13)
 

--- a/js-miniapp-sdk/CHANGELOG.md
+++ b/js-miniapp-sdk/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## CHANGELOG
 
 ### In Progress (2020-XX-XX)
-- **Feature:** Added `rakuten.miniapp.device.LOCATION` custom permission.
+- **Feature:** Added `CustomPermissionName.LOCATION`. From now `requestLocationPermission` will request both custom and device permission respectively.
 
 ### 1.5.0 (2020-11-13)
 

--- a/js-miniapp-sdk/CHANGELOG.md
+++ b/js-miniapp-sdk/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## CHANGELOG
 
+### In Progress (2020-XX-XX)
+- **Feature:** Added `rakuten.miniapp.device.location` custom permission.
+
 ### 1.5.0 (2020-11-13)
 
 - **Feature:** Added `MiniApp.getAccessToken` for retrieving an access token. [See here](README.md#6-Get-access-token).

--- a/js-miniapp-sdk/CHANGELOG.md
+++ b/js-miniapp-sdk/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## CHANGELOG
 
 ### In Progress (2020-XX-XX)
-- **Feature:** Added `rakuten.miniapp.device.location` custom permission.
+- **Feature:** Added `rakuten.miniapp.device.LOCATION` custom permission.
 
 ### 1.5.0 (2020-11-13)
 

--- a/js-miniapp-sdk/CHANGELOG.md
+++ b/js-miniapp-sdk/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## CHANGELOG
 
 ### In Progress (2020-XX-XX)
-- **Feature:** Added `CustomPermissionName.LOCATION`. From now `requestLocationPermission` will request both custom and device permission respectively.
+- **Feature:** Added `CustomPermissionName.LOCATION`.
+- **Change:** Updated `requestLocationPermission()`` to `requestLocationPermission(description?: string)`. From now `requestLocationPermission` will request both custom and device permission respectively.
 
 ### 1.5.0 (2020-11-13)
 

--- a/js-miniapp-sdk/README.md
+++ b/js-miniapp-sdk/README.md
@@ -70,8 +70,9 @@ Note that there are two types of permissions:
 
 | Permission | Type | Method | Description |
 | --- | --- | --- | --- |
-| LOCATION | Device | `requestLocationPermission()` | The current location permission of the device.<br>Data position can be accessible via geolocation request (`navigator.geolocation`). |
-| User Data | Custom | `requestCustomPermission()` | Custom permissions for User Data. Currently supported types are `CustomPermissionName.USER_NAME`, `CustomPermissionName.PROFILE_PHOTO`, and `CustomPermissionName.CONTACT_LIST`. These permisions should be requested before you attempt to access the User's data. |
+| Location | Device | `requestLocationPermission()` | The current location permission of the device.<br>Data position can be accessible via geolocation request (`navigator.geolocation`). |
+| Location | Custom | `requestCustomPermissions()` | Custom permission for device location. Currently supported type is `CustomPermissionName.LOCATION`. |
+| User Data | Custom | `requestCustomPermissions()` | Custom permissions for User Data. Currently supported types are `CustomPermissionName.USER_NAME`, `CustomPermissionName.PROFILE_PHOTO`, and `CustomPermissionName.CONTACT_LIST`. These permissions should be requested before you attempt to access the User's data. |
 
 #### Usage example
 
@@ -86,24 +87,6 @@ miniApp.requestLocationPermission('This description will be shown to the user.')
 	}).catch(error => {
 		console.error(error); // Permission is not granted due to many circumstances.
     });
-```
-
-```javascript
-// Location custom permission
-import miniApp, { CustomPermissionResult, CustomPermissionName} from 'js-miniapp-sdk';
-miniApp.requestCustomPermissions([
-    {name: CustomPermissionName.LOCATION, description: 'This text will be shown to the user.'},
-]).then((result) => {
-    const allowed = result
-        .filter(permission => permission.status === CustomPermissionResult.ALLOWED)
-        .map(permission => permisssion.name);
-
-    if (allowed.indexOf(CustomPermissionName.LOCATION) > -1) {
-        // Access and use the location data
-    }
-}).catch(error => {
-    console.error(error); // An error occured
-});
 ```
 
 ```javascript

--- a/js-miniapp-sdk/README.md
+++ b/js-miniapp-sdk/README.md
@@ -70,7 +70,7 @@ Note that there are two types of permissions:
 
 | Permission | Type | Method | Description |
 | --- | --- | --- | --- |
-| LOCATION | Device | `requestLocationPermission()` | The current location of the device.<br>Data position can be accessible via geolocation request (`navigator.geolocation`). |
+| LOCATION | Device | `requestLocationPermission()` | The current location permission of the device.<br>Data position can be accessible via geolocation request (`navigator.geolocation`). |
 | User Data | Custom | `requestCustomPermission()` | Custom permissions for User Data. Currently supported types are `CustomPermissionName.USER_NAME`, `CustomPermissionName.PROFILE_PHOTO`, and `CustomPermissionName.CONTACT_LIST`. These permisions should be requested before you attempt to access the User's data. |
 
 #### Usage example
@@ -86,6 +86,24 @@ miniApp.requestLocationPermission()
 	}).catch(error => {
 		console.error(error); // Permission is not granted due to many circumstances.
     });
+```
+
+```javascript
+// Location custom permission
+import miniApp, { CustomPermissionResult, CustomPermissionName} from 'js-miniapp-sdk';
+miniApp.requestCustomPermissions([
+    {name: CustomPermissionName.LOCATION, description: 'This text will be shown to the user.'},
+]).then((result) => {
+    const allowed = result
+        .filter(permission => permission.status === CustomPermissionResult.ALLOWED)
+        .map(permission => permisssion.name);
+
+    if (allowed.indexOf(CustomPermissionName.LOCATION) > -1) {
+        // Access and use the location data
+    }
+}).catch(error => {
+    console.error(error); // An error occured
+});
 ```
 
 ```javascript

--- a/js-miniapp-sdk/README.md
+++ b/js-miniapp-sdk/README.md
@@ -80,7 +80,7 @@ Simply call available permission request methods from `miniApp`.
 ```javascript
 // Location Permission
 import miniApp from 'js-miniapp-sdk';
-miniApp.requestLocationPermission()
+miniApp.requestLocationPermission('This description will be shown to the user.')
 	.then(success => {
 		console.log(success); // Allowed.
 	}).catch(error => {

--- a/js-miniapp-sdk/README.md
+++ b/js-miniapp-sdk/README.md
@@ -70,8 +70,7 @@ Note that there are two types of permissions:
 
 | Permission | Type | Method | Description |
 | --- | --- | --- | --- |
-| Location | Device | `requestLocationPermission()` | The current location permission of the device.<br>Data position can be accessible via geolocation request (`navigator.geolocation`). |
-| Location | Custom | `requestCustomPermissions()` | Custom permission for device location. Currently supported type is `CustomPermissionName.LOCATION`. |
+| Location | Custom & Device | `requestLocationPermission()` | Custom and device permission respectively for location. Currently supported types are `CustomPermissionName.LOCATION` & `DevicePermission.LOCATION`.<br>Location data can be accessible via geolocation request (`navigator.geolocation`). |
 | User Data | Custom | `requestCustomPermissions()` | Custom permissions for User Data. Currently supported types are `CustomPermissionName.USER_NAME`, `CustomPermissionName.PROFILE_PHOTO`, and `CustomPermissionName.CONTACT_LIST`. These permissions should be requested before you attempt to access the User's data. |
 
 #### Usage example

--- a/js-miniapp-sdk/src/miniapp.ts
+++ b/js-miniapp-sdk/src/miniapp.ts
@@ -3,7 +3,9 @@ import {
   Reward,
   DevicePermission,
   CustomPermission,
+  CustomPermissionName,
   CustomPermissionResult,
+  CustomPermissionStatus,
   ShareInfoType,
   ScreenOrientation,
   AccessTokenData,
@@ -146,7 +148,22 @@ export class MiniApp implements MiniAppFeatures, Ad, Platform {
   }
 
   requestLocationPermission(): Promise<string> {
-    return this.requestPermission(DevicePermission.LOCATION);
+    const locationPermission = [
+      {
+        name: CustomPermissionName.LOCATION,
+        description: 'We would like to display the location of your device.',
+      },
+    ];
+
+    return this.requestCustomPermissions(locationPermission)
+      .then(permission =>
+        permission.find(
+          result => result.status === CustomPermissionStatus.ALLOWED
+        )
+      )
+      .then(hasPermission =>
+        hasPermission ? this.requestPermission(DevicePermission.LOCATION) : null
+      );
   }
 
   requestCustomPermissions(

--- a/js-miniapp-sdk/src/miniapp.ts
+++ b/js-miniapp-sdk/src/miniapp.ts
@@ -18,8 +18,11 @@ interface MiniAppFeatures {
   /** @returns The Promise of provided id of mini app from injected side. */
   getUniqueId(): Promise<string>;
 
-  /** @returns The Promise of permission result of mini app from injected side. */
-  requestLocationPermission(permissionDescription: string): Promise<string>;
+  /**
+   * @param Description of location permission.
+   * @returns The Promise of permission result of mini app from injected side.
+   */
+  requestLocationPermission(permissionDescription?: string): Promise<string>;
 
   /**
    *

--- a/js-miniapp-sdk/src/miniapp.ts
+++ b/js-miniapp-sdk/src/miniapp.ts
@@ -19,7 +19,7 @@ interface MiniAppFeatures {
   getUniqueId(): Promise<string>;
 
   /** @returns The Promise of permission result of mini app from injected side. */
-  requestLocationPermission(): Promise<string>;
+  requestLocationPermission(permissionDescription: string): Promise<string>;
 
   /**
    *
@@ -147,7 +147,7 @@ export class MiniApp implements MiniAppFeatures, Ad, Platform {
     return this.bridge.getUniqueId();
   }
 
-  requestLocationPermission(permissionDescription?: string): Promise<string> {
+  requestLocationPermission(permissionDescription = ''): Promise<string> {
     const locationPermission = [
       {
         name: CustomPermissionName.LOCATION,

--- a/js-miniapp-sdk/src/miniapp.ts
+++ b/js-miniapp-sdk/src/miniapp.ts
@@ -147,11 +147,11 @@ export class MiniApp implements MiniAppFeatures, Ad, Platform {
     return this.bridge.getUniqueId();
   }
 
-  requestLocationPermission(): Promise<string> {
+  requestLocationPermission(permissionDescription?: string): Promise<string> {
     const locationPermission = [
       {
         name: CustomPermissionName.LOCATION,
-        description: 'We would like to display the location of your device.',
+        description: permissionDescription,
       },
     ];
 

--- a/js-miniapp-sdk/test/miniapp.spec.ts
+++ b/js-miniapp-sdk/test/miniapp.spec.ts
@@ -55,9 +55,9 @@ describe('requestPermission', () => {
   it('should delegate to requestPermission function when request any permission', () => {
     const spy = sinon.spy(miniApp, 'requestPermission' as any);
 
-    miniApp.requestLocationPermission();
-
-    return expect(spy.callCount).to.equal(0);
+    return miniApp
+      .requestLocationPermission()
+      .then(denied => expect(spy.callCount).to.equal(1));
   });
 
   it('should retrieve location permission result from the Mini App Bridge', () => {

--- a/js-miniapp-sdk/test/miniapp.spec.ts
+++ b/js-miniapp-sdk/test/miniapp.spec.ts
@@ -43,12 +43,21 @@ describe('getUniqueId', () => {
 });
 
 describe('requestPermission', () => {
+  window.MiniAppBridge.requestCustomPermissions.resolves({
+    permissions: [
+      {
+        name: CustomPermissionName.LOCATION,
+        status: CustomPermissionStatus.ALLOWED,
+      },
+    ],
+  });
+
   it('should delegate to requestPermission function when request any permission', () => {
     const spy = sinon.spy(miniApp, 'requestPermission' as any);
 
     miniApp.requestLocationPermission();
 
-    return expect(spy.callCount).to.equal(1);
+    return expect(spy.callCount).to.equal(0);
   });
 
   it('should retrieve location permission result from the Mini App Bridge', () => {


### PR DESCRIPTION
# Description
- Add a custom permission type for `rakuten.miniapp.device.location`.
- We need to consider how this permission fits into the flow of the native device permission for LOCATION. This PR aims to request for the device location using `requestCustomPermissions` first before it will ask by `requestPermission`. It will add the solution inside sdk as default implementation instead of sample app.

## Links
- MINI-1956

# Checklist
- [x] I wrote/updated tests for new/changed code.
- [x] I ran `yarn sdk buildSdk` and `yarn bridge buildBridge` without issues.
- [x] I ran `yarn sample prettify` and `yarn sample build` without issues.
