### PR TITLE
ci: Deploy sample app to gh-pages branch on master merge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,10 +23,54 @@ commands:
               echo "Nothing to commit"
             fi
 
-jobs: # a collection of steps
-  build-sdk: # runs not using Workflows must have a `build` job as entry point
-    working_directory: ~/mini-js-sdk # directory where steps will run
-    docker: # run the steps with Docker
+jobs: 
+  build-bridge:
+    working_directory: ~/mini-js-bridge
+    docker:
+      - image: circleci/node:10.16.3
+    steps:
+      - checkout
+      - restore_cache:
+          name: Restore Yarn Package Cache
+          key: yarn-packages-{{ checksum "yarn.lock" }}
+      - run:
+          name: Install dependencies w/ Yarn
+          command: yarn install --frozen-lockfile
+      - save_cache:
+          name: Save Yarn Package Cache
+          key: yarn-packages-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/.cache/yarn
+      - run:
+          name: Test
+          command: yarn bridge test
+      - run:
+          name: Lint
+          command: yarn bridge lint
+      - run:
+          name: Compile
+          command: yarn bridge compile
+      - persist_to_workspace:
+          root: ~/mini-js-bridge
+          paths:
+            - js-miniapp-bridge/build/
+
+  export-bridge:
+    working_directory: ~/mini-js-bridge
+    docker:
+      - image: circleci/node:10.16.3
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ./
+      - export-js-bridge:
+          platform: ios
+      - export-js-bridge:
+          platform: android
+
+  build-sdk:
+    working_directory: ~/mini-js-sdk
+    docker:
       - image: circleci/node:10.16.3
     steps:
       - checkout
@@ -80,49 +124,47 @@ jobs: # a collection of steps
             - js-miniapp-sdk/build/
             - js-miniapp-sdk/publishableDocs/
 
-  build-bridge:
-    working_directory: ~/mini-js-bridge
-    docker:
-      - image: circleci/node:10.16.3
-    steps:
-      - checkout
-      - restore_cache:
-          name: Restore Yarn Package Cache
-          key: yarn-packages-{{ checksum "yarn.lock" }}
-      - run:
-          name: Install dependencies w/ Yarn
-          command: yarn install --frozen-lockfile
-      - save_cache:
-          name: Save Yarn Package Cache
-          key: yarn-packages-{{ checksum "yarn.lock" }}
-          paths:
-            - ~/.cache/yarn
-      - run:
-          name: Test
-          command: yarn bridge test
-      - run:
-          name: Lint
-          command: yarn bridge lint
-      - run:
-          name: Compile
-          command: yarn bridge compile
-      - persist_to_workspace:
-          root: ~/mini-js-bridge
-          paths:
-            - js-miniapp-bridge/build/
-
-  export-bridge:
-    working_directory: ~/mini-js-bridge
+  publish-sdk:
+    working_directory: ~/mini-js-sdk
     docker:
       - image: circleci/node:10.16.3
     steps:
       - checkout
       - attach_workspace:
           at: ./
-      - export-js-bridge:
-          platform: ios
-      - export-js-bridge:
-          platform: android
+      - run:
+          name: publish to NPM
+          command: |
+            npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN
+            yarn sdk publish
+      - run:
+          name: Publish Documentation
+          command: |
+            set -e
+            if [[ ! $CIRCLE_TAG == *"-"* ]]; then
+              git checkout gh-pages
+              cp -R ./js-miniapp-sdk/publishableDocs/docs/. ./docs
+              cp -R ./js-miniapp-sdk/publishableDocs/_versions/. ./_versions
+              git add docs _versions
+              git config user.name "CI Publisher"
+              git config user.email "dev-opensource@mail.rakuten.com"
+              git commit -m "Publish documentation for $CIRCLE_TAG"
+              git push origin gh-pages
+            else
+              echo "Documentation not published for snapshot version"
+            fi
+      - run:
+          name: Publish GitHub Release
+          command: |
+            set -e
+            curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
+            if [[ ! $CIRCLE_TAG == *"-"* ]]; then
+              echo "Publishing $CIRCLE_TAG release to GitHub"
+              ./bin/hub release create -a ./js-miniapp-sdk/build/miniapp.bundle.js -m $CIRCLE_TAG $CIRCLE_TAG
+            else
+              echo "Publishing $CIRCLE_TAG pre-release to GitHub"
+              ./bin/hub release create --prerelease -a ./js-miniapp-sdk/build/miniapp.bundle.js -m $CIRCLE_TAG $CIRCLE_TAG
+            fi
 
   build-sample: # builds  & tests the sample app against latest sdk build.
     working_directory: ~/js-miniapp-sample
@@ -184,58 +226,10 @@ jobs: # a collection of steps
               echo "Nothing to commit"
             fi
 
-  publish-sdk:
-    working_directory: ~/mini-js-sdk
-    docker:
-      - image: circleci/node:10.16.3
-    steps:
-      - checkout
-      - attach_workspace:
-          at: ./
-      - run:
-          name: publish to NPM
-          command: |
-            npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN
-            yarn sdk publish
-      - run:
-          name: Publish Documentation
-          command: |
-            set -e
-            if [[ ! $CIRCLE_TAG == *"-"* ]]; then
-              git checkout gh-pages
-              cp -R ./js-miniapp-sdk/publishableDocs/docs/. ./docs
-              cp -R ./js-miniapp-sdk/publishableDocs/_versions/. ./_versions
-              git add docs _versions
-              git config user.name "CI Publisher"
-              git config user.email "dev-opensource@mail.rakuten.com"
-              git commit -m "Publish documentation for $CIRCLE_TAG"
-              git push origin gh-pages
-            else
-              echo "Documentation not published for snapshot version"
-            fi
-      - run:
-          name: Publish GitHub Release
-          command: |
-            set -e
-            curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-            if [[ ! $CIRCLE_TAG == *"-"* ]]; then
-              echo "Publishing $CIRCLE_TAG release to GitHub"
-              ./bin/hub release create -a ./js-miniapp-sdk/build/miniapp.bundle.js -m $CIRCLE_TAG $CIRCLE_TAG
-            else
-              echo "Publishing $CIRCLE_TAG pre-release to GitHub"
-              ./bin/hub release create --prerelease -a ./js-miniapp-sdk/build/miniapp.bundle.js -m $CIRCLE_TAG $CIRCLE_TAG
-            fi
-
 workflows:
   version: 2
   build-and-release:
     jobs:
-      - build-sdk:
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              only: /.*/
       - build-bridge
       - export-bridge:
           requires:
@@ -243,13 +237,12 @@ workflows:
           filters:
             branches:
               only: master
-      - build-sample
-      - deploy-sample:
-          requires:
-           - build-sample
+      - build-sdk:
           filters:
+            tags:
+              only: /^v.*/
             branches:
-              only: master
+              only: /.*/
       - sdk-release-verification:
           type: approval
           requires:
@@ -267,3 +260,10 @@ workflows:
               only: /^v.*/
             branches:
               ignore: /.*/
+      - build-sample
+      - deploy-sample:
+          requires:
+           - build-sample
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,9 +106,6 @@ jobs: # a collection of steps
       - run:
           name: Compile
           command: yarn bridge compile
-      - store_artifacts:
-          path: js-miniapp-sample/build
-          prefix: build
       - persist_to_workspace:
           root: ~/mini-js-bridge
           paths:
@@ -132,6 +129,8 @@ jobs: # a collection of steps
     docker:
       - image: circleci/node:12.16.2
       # TODO get the sdk build from saved workspace
+    environment:
+      PUBLIC_URL: .
     steps:
       - checkout
       - restore_cache:
@@ -157,6 +156,33 @@ jobs: # a collection of steps
       - run:
           name: build
           command: yarn sample build
+      - store_artifacts:
+          path: js-miniapp-sample/build
+          prefix: build
+
+  deploy-sample:
+    working_directory: ~/js-miniapp-sample
+    docker:
+      - image: circleci/node:10.16.3
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ./
+      - run:
+          name: Deploy Sample App to Github Pages
+          command: |
+            set -e
+            git checkout gh-pages
+            cp -r ./js-miniapp-sample/build/ ./sample
+            if [[ `git status sample --porcelain` ]]; then
+              git add sample
+              git config user.name "CI Publisher"
+              git config user.email "dev-opensource@mail.rakuten.com"
+              git commit -m "sample: Deploy JS Sample App [ci skip]"
+              git push origin gh-pages
+            else
+              echo "Nothing to commit"
+            fi
 
   publish-sdk:
     working_directory: ~/mini-js-sdk
@@ -218,6 +244,12 @@ workflows:
             branches:
               only: master
       - build-sample
+      - deploy-sample:
+          requires:
+           - build-sample
+          filters:
+            branches:
+              only: master
       - sdk-release-verification:
           type: approval
           requires:

--- a/README.md
+++ b/README.md
@@ -45,3 +45,12 @@ The following describes the steps performed by CI when releasing a new version o
 4. If approved, publish the JS SDK to [NPM](https://www.npmjs.com/package/js-miniapp-sdk).
 5. Publish documentation to the [Github Pages site](https://rakutentech.github.io/js-miniapp/docs/1.1/).
 6. Publish a release to [Github Releases page](https://github.com/rakutentech/js-miniapp/releases) and attach a JavaScript bundle of the SDK (`miniapp.bundle.js`).
+
+### JavaScript Bridge Deployment
+
+The JavaScript bridge ([js-miniapp-bridge](js-miniapp-bridge)) will be deployed to the [js-bridge-android](tree/js-bridge-android) and [js-bridge-ios](/tree/js-bridge-ios) branches when changes are merged to master. These branches are then imported as Git Submodules in the Android and iOS Mini App SDK repos.
+
+
+### Sample App Deployment
+
+The sample app ([js-miniapp-sample](js-miniapp-sample)) will be deployed to the [gh-pages](tree/gh-pages) branch when changes are merged to master. This can be viewed [here](https://rakutentech.github.io/js-miniapp/sample).


### PR DESCRIPTION
# Description
This is so we can test the JS Sample App as a website using the new SDK feature.

I'm a little bit sad about using the `gh-pages` branch for multiple purposes (hosting both docs and the sample app) - but I think this is the most simple and straightforward way of deploying. I guess it's just a disadvantage of using a mono-repo.

# Checklist
- [x] I wrote/updated tests for new/changed code.
- [x] I ran `yarn sdk buildSdk` and `yarn bridge buildBridge` without issues.
- [x] I ran `yarn sample prettify` and `yarn sample build` without issues.
