### PR TITLE
External webview: allow parameters to be passed and received

### DIFF
--- a/js-miniapp-sample/external-webview/index.html
+++ b/js-miniapp-sample/external-webview/index.html
@@ -20,6 +20,14 @@
             li {
                 margin: 0.5em 0;
             }
+            a.button {
+                border: 1px solid #ccc;
+                border-radius: 5px;
+                padding: 6px 10px;
+                text-decoration: none;
+                background: #eee;
+                color: #111;
+            }
         </style>
     </head>
     <body>
@@ -48,5 +56,69 @@
                 <a href ="#" onclick="window.open('https://www.google.com')" id="new-window-js">Google</a>
             </li>
         </ul>
-    </body>
+
+        <h3>Received Parameters</h3>
+        <ul>
+            <li id="PassedParams" style="line-break: anywhere"></li>
+        </ul>
+
+        <h3>Return To Mini App</h3>
+        <br />
+        <div>
+            <label>Params to send mini app:</label>
+            <br />
+            <input id="ReturnInput" 
+                placeholder="Enter params to send Mini App"
+                value="?testParam=someValue&test2=anotherValue" 
+                style="width: 250px;" />
+            <br />
+            <br />
+            <a class="button" id="ReturnButton">Return to Mini App</a>
+        </div>
+
+        <script>
+            function getParam(name) {
+                const params = window.location.search;
+                if (params) {
+                    const param = params.substr(1).split("&")
+                        .map(param => param.split("="))
+                        .find(pair => pair[0] === name);
+                    return param && param[1];
+                } else {
+                    return null;
+                }
+            }
+
+            function validateParams(params) {
+                if (!params.startsWith('?') || params.indexOf('=') <= -1) {
+                    return false;
+                }
+                return true;
+            }
+
+            (function() {
+                // Set Params field
+                const passedParams = window.location.search
+                    // This page is loaded via a query parameter so we must remove the section which isn't relevant
+                    .replace(/^[?](.*?)[?]/, '?'); 
+                document.getElementById('PassedParams').innerHTML = passedParams || 'None';
+
+                // Set return URL and params
+                const returnInput = document.getElementById('ReturnInput');
+                const returnButton = document.getElementById('ReturnButton');
+                const callbackUrl = decodeURIComponent( getParam('callbackUrl') );
+                const setReturnHref = () => returnButton.href = callbackUrl + returnInput.value;
+                setReturnHref();
+                returnInput.onchange = setReturnHref;
+
+                // Validate params on button click
+                returnButton.onclick = (e) => {
+                    if (!validateParams(returnInput.value)) {
+                        e.preventDefault();
+                        alert("Invalid params were defined!");
+                    }
+                }
+            })();
+        </script>
+    </body> 
 </html>

--- a/js-miniapp-sample/src/pages/home.js
+++ b/js-miniapp-sample/src/pages/home.js
@@ -7,12 +7,7 @@ import {
   useMediaQuery,
 } from '@material-ui/core';
 import clsx from 'clsx';
-import {
-  BrowserRouter as Router,
-  Route,
-  Switch,
-  Redirect,
-} from 'react-router-dom';
+import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 
 import ToolBar from '../components/ToolBar';
 import { navItems } from './../routes';
@@ -91,9 +86,6 @@ const Home = (props: any) => {
       >
         <Container className={classes.wrapperContainer}>
           <Switch>
-            <Route exact path={['/', '/miniapp/index.html', '/index.html']}>
-              <Redirect to={navItems[0].navLink} />
-            </Route>
             {navItems.map((it) => (
               <Route
                 key={it.navLink}
@@ -112,7 +104,7 @@ const Home = (props: any) => {
                 }
               ></Route>
             ))}
-            <Route path="*">Page Not Found</Route>
+            <Route path="*" component={navItems[0].component}></Route>
           </Switch>
         </Container>
       </main>

--- a/js-miniapp-sample/src/pages/landing.js
+++ b/js-miniapp-sample/src/pages/landing.js
@@ -24,6 +24,8 @@ const useStyles = makeStyles((theme) => ({
   },
   info: {
     fontSize: 16,
+    lineBreak: 'anywhere',
+    marginTop: 0,
   },
 }));
 
@@ -34,6 +36,9 @@ const Landing = () => {
       <CardContent className={classes.content}>
         <p>Demo Mini App JS SDK</p>
         <p className={classes.info}>Platform: {MiniApp.getPlatform()}</p>
+        <p className={classes.info}>
+          Parameters: {window.location.search || 'None'}
+        </p>
       </CardContent>
     </GreyCard>
   );

--- a/js-miniapp-sample/src/pages/uri-schemes.js
+++ b/js-miniapp-sample/src/pages/uri-schemes.js
@@ -1,16 +1,21 @@
 // @flow
-import React from 'react';
+import React, { useState } from 'react';
 
 import {
   Button,
   CardContent,
   CardActions,
+  TextField,
   makeStyles,
 } from '@material-ui/core';
 
 import GreyCard from '../components/GreyCard';
 
 const useStyles = makeStyles((theme) => ({
+  actions: {
+    justifyContent: 'center',
+    paddingBottom: 16,
+  },
   card: {
     height: 'auto',
   },
@@ -24,14 +29,41 @@ const useStyles = makeStyles((theme) => ({
     fontWeight: 'bold',
     paddingBottom: 0,
   },
-  actions: {
-    justifyContent: 'center',
-    paddingBottom: 16,
+  textfield: {
+    width: '100%',
   },
 }));
 
 const UriSchemes = () => {
+  const EXTERNAL_WEBVIEW_URL =
+    'https://htmlpreview.github.io/?https://raw.githubusercontent.com/rakutentech/js-miniapp/master/js-miniapp-sample/external-webview/index.html';
   const classes = useStyles();
+  const [params, setParams] = useState('?testSendParam=someValue&test2=test2');
+
+  function validateParams(params) {
+    if (!params.startsWith('?') || params.indexOf('=') <= -1) {
+      return false;
+    }
+
+    return true;
+  }
+
+  function onOpenExternalWebview() {
+    if (params && !validateParams(params)) {
+      window.alert(
+        'Invalid params. Please input params in the format ?param1=value1&param2=value2'
+      );
+      return;
+    }
+
+    const callbackUrl = `${window.location.protocol}//${window.location.host}/index.html`;
+    const paramsWithCallback = params
+      .concat(params ? '&' : '?')
+      .concat(`callbackUrl=${encodeURIComponent(callbackUrl)}`);
+
+    window.location.href = EXTERNAL_WEBVIEW_URL + paramsWithCallback;
+  }
+
   return (
     <GreyCard className={classes.card}>
       <CardContent className={classes.content}>tel: scheme</CardContent>
@@ -53,11 +85,24 @@ const UriSchemes = () => {
       </CardActions>
 
       <CardContent className={classes.content}>External Webview</CardContent>
+      <CardContent className={classes.content}>
+        <TextField
+          className={classes.textfield}
+          onChange={(e) => setParams(e.currentTarget.value)}
+          value={params}
+          label="Params to pass"
+          variant="outlined"
+          color="primary"
+          inputProps={{
+            'data-testid': 'input-field',
+          }}
+        />
+      </CardContent>
       <CardActions className={classes.actions}>
         <Button
           variant="contained"
           color="primary"
-          href="https://htmlpreview.github.io/?https://raw.githubusercontent.com/rakutentech/js-miniapp/master/js-miniapp-sample/external-webview/index.html"
+          onClick={onOpenExternalWebview}
         >
           Open
         </Button>


### PR DESCRIPTION
# Description
This was done by updating `external-webview/index.html` to allow receiving parameters and also sending a "callback URL" to this page (the URL of the mini app).

On the external webview page, the user can also set parameters which will be returned to the JS SDK Sample App, and the sample app will display these parameters on the landing page.

<img src="https://user-images.githubusercontent.com/15662659/101862421-aa775a00-3bb5-11eb-9212-2f73319448c6.png" width="300px" />
<img src="https://user-images.githubusercontent.com/15662659/101862426-ac411d80-3bb5-11eb-90af-1e14dd54005c.png" width="300px" />
<img src="https://user-images.githubusercontent.com/15662659/101862431-ae0ae100-3bb5-11eb-8ea2-f4afdf68065d.png" width="300px" />

# Checklist
- [ ] I wrote/updated tests for new/changed code.
- [x] I ran `yarn sdk buildSdk` and `yarn bridge buildBridge` without issues.
- [x] I ran `yarn sample prettify` and `yarn sample build` without issues.
