### PR TITLE
ci: Fix sample app deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,7 +219,9 @@ jobs:
           command: |
             set -e
             git checkout gh-pages
-            cp -r ./js-miniapp-sample/build/ ./sample
+            rm -rf ./sample
+            mkdir sample
+            cp -r ./js-miniapp-sample/build/* ./sample
             if [[ `git status sample --porcelain` ]]; then
               git add sample
               git config user.name "CI Publisher"


### PR DESCRIPTION
# Description
Sample app wasn't getting deployed becuase of a difference with the bash environment on CI (it requires folders to be copied using '*' to specificy all files in the folder).

Also added commands to delete the 'sample' folder first before copying - this ensures that old, unusd files get removed

## Links
MINI-2403

# Checklist
- [ ] I wrote/updated tests for new/changed code.
- [ ] I ran `yarn sdk buildSdk` and `yarn bridge buildBridge` without issues.
- [ ] I ran `yarn sample prettify` and `yarn sample build` without issues.
