### PR TITLE
build: fix keep publishableDocs

### DIFF
--- a/js-miniapp-sdk/scripts/docs.sh
+++ b/js-miniapp-sdk/scripts/docs.sh
@@ -16,9 +16,6 @@ version: "$PACKAGE_VERSION"
 ---"
 cat <<< "$contents" > "$FILE_VERSION_MD"
 
-# Clean docs folder
-rm -rf publishableDocs
-
 # Generate docs
 npx typedoc --out $DIR_DOCS/api src --options typedoc.json
 


### PR DESCRIPTION
# Description
Keep publishable documents for CI release.

# Checklist
- [ ] I wrote/updated tests for new/changed code.
- [x] I ran `yarn sdk buildSdk` and `yarn bridge buildBridge` without issues.
- [x] I ran `yarn sample prettify` and `yarn sample build` without issues.
