### PR TITLE
MINIBUILD-719/feat: display banner ads

### DIFF
--- a/js-miniapp-bridge/src/common-bridge.ts
+++ b/js-miniapp-bridge/src/common-bridge.ts
@@ -218,7 +218,7 @@ export class MiniAppBridge {
       return this.executor.exec(
         'showAd',
         { adType: AdTypes.BANNER, adUnitId: id },
-        showSuccess => resolve(showSuccess),
+        appearSuccess => resolve(appearSuccess),
         error => reject(error)
       );
     });

--- a/js-miniapp-bridge/src/common-bridge.ts
+++ b/js-miniapp-bridge/src/common-bridge.ts
@@ -193,6 +193,38 @@ export class MiniAppBridge {
   }
 
   /**
+   * Associating loadBannerAd function to MiniAppBridge object.
+   * This function preloads Banner ad before they are requested for display.
+   * Can be called multiple times to pre-load multiple ads.
+   * @param {string} id ad unit id of the Banner ad that needs to be loaded.
+   */
+  loadBannerAd(id: string) {
+    return new Promise<string>((resolve, reject) => {
+      return this.executor.exec(
+        'loadAd',
+        { adType: AdTypes.BANNER, adUnitId: id },
+        loadSuccess => resolve(loadSuccess),
+        error => reject(error)
+      );
+    });
+  }
+
+  /**
+   * Associating showBannerAd function to MiniAppBridge object.
+   * @param {string} id ad unit id of the Banner ad that will be shown.
+   */
+  showBannerAd(id: string) {
+    return new Promise<string>((resolve, reject) => {
+      return this.executor.exec(
+        'showAd',
+        { adType: AdTypes.BANNER, adUnitId: id },
+        showSuccess => resolve(showSuccess),
+        error => reject(error)
+      );
+    });
+  }
+
+  /**
    * Associating requestCustomPermissions function to MiniAppBridge object
    * @param [CustomPermissionType[] permissionTypes, Types of custom permissions that are requested
    * using an Array including the parameters eg. name, description.

--- a/js-miniapp-bridge/src/common-bridge.ts
+++ b/js-miniapp-bridge/src/common-bridge.ts
@@ -193,23 +193,6 @@ export class MiniAppBridge {
   }
 
   /**
-   * Associating loadBannerAd function to MiniAppBridge object.
-   * This function preloads Banner ad before they are requested for display.
-   * Can be called multiple times to pre-load multiple ads.
-   * @param {string} id ad unit id of the Banner ad that needs to be loaded.
-   */
-  loadBannerAd(id: string) {
-    return new Promise<string>((resolve, reject) => {
-      return this.executor.exec(
-        'loadAd',
-        { adType: AdTypes.BANNER, adUnitId: id },
-        loadSuccess => resolve(loadSuccess),
-        error => reject(error)
-      );
-    });
-  }
-
-  /**
    * Associating showBannerAd function to MiniAppBridge object.
    * @param {string} id ad unit id of the Banner ad that will be shown.
    */

--- a/js-miniapp-bridge/src/types/ad-types/index.ts
+++ b/js-miniapp-bridge/src/types/ad-types/index.ts
@@ -3,6 +3,7 @@
  * These ad formats replicate formats supported by Google
  */
 export const enum AdTypes {
+  BANNER,
   INTERSTITIAL,
   REWARDED,
 }

--- a/js-miniapp-bridge/test/test.spec.ts
+++ b/js-miniapp-bridge/test/test.spec.ts
@@ -101,6 +101,18 @@ describe('showInterstitialAd', () => {
   });
 });
 
+describe('showBannerAd', () => {
+  it('will return the successfully shown status string response', () => {
+    const bridge = new Bridge.MiniAppBridge(mockExecutor);
+    const response = 'appeared';
+    mockExecutor.exec.callsArgWith(2, response);
+
+    return expect(bridge.showBannerAd('test_id')).to.eventually.deep.equal(
+      response
+    );
+  });
+});
+
 describe('requestCustomPermissions', () => {
   const requestPermissions = [
     { name: CustomPermissionName.USER_NAME, description: 'test_description' },

--- a/js-miniapp-sample/src/pages/ads.js
+++ b/js-miniapp-sample/src/pages/ads.js
@@ -165,7 +165,7 @@ function Ads() {
       .catch(handleRewardFailure);
   };
 
-  const loadBannerlAd = () => {
+  const loadBannerAd = () => {
     bannerDispatch({ type: 'LOADING' });
     MiniApp.loadBannerAd(bannerAdId)
       .then(handleBannerSuccess)
@@ -287,7 +287,7 @@ function Ads() {
           {renderButton({
             text: 'Load Banner',
             disabled: bannerState.isLoading,
-            onClick: loadBannerlAd,
+            onClick: loadBannerAd,
           })}
           {renderButton({
             text: 'Show Banner',

--- a/js-miniapp-sample/src/pages/ads.js
+++ b/js-miniapp-sample/src/pages/ads.js
@@ -290,7 +290,7 @@ function Ads() {
             onClick: loadBannerlAd,
           })}
           {renderButton({
-            text: 'Show Interstitial',
+            text: 'Show Banner',
             disabled: bannerState.isLoading,
             onClick: displayBannerAd,
           })}

--- a/js-miniapp-sample/src/pages/ads.js
+++ b/js-miniapp-sample/src/pages/ads.js
@@ -99,11 +99,18 @@ function Ads() {
     dataFetchReducer,
     initialState
   );
+  const [bannerState, bannerDispatch] = useReducer(
+    dataFetchReducer,
+    initialState
+  );
   const [interstitialAdId, setInterstitialAdId] = useState(
     'ca-app-pub-3940256099942544/1033173712'
   );
   const [rewardAdId, setRewardAdId] = useState(
     'ca-app-pub-3940256099942544/5224354917'
+  );
+  const [bannerAdId, setBannerAdId] = useState(
+    'ca-app-pub-3940256099942544/6300978111'
   );
   const classes = useStyles();
 
@@ -113,6 +120,14 @@ function Ads() {
   };
   const handleInterstitialFailure = (error) => {
     interstitialDispatch({ type: 'FAILURE', error });
+    console.error(error);
+  };
+  const handleBannerSuccess = (loadSuccess) => {
+    bannerDispatch({ type: 'SUCCESS' });
+    console.log(loadSuccess);
+  };
+  const handleBannerFailure = (error) => {
+    bannerDispatch({ type: 'FAILURE', error });
     console.error(error);
   };
   const loadInterstitialAd = () => {
@@ -148,6 +163,19 @@ function Ads() {
         rewardDispatch({ type: 'SUCCESS', rewardItem: reward });
       })
       .catch(handleRewardFailure);
+  };
+
+  const loadBannerlAd = () => {
+    bannerDispatch({ type: 'LOADING' });
+    MiniApp.loadBannerAd(bannerAdId)
+      .then(handleBannerSuccess)
+      .catch(handleBannerFailure);
+  };
+  const displayBannerAd = () => {
+    bannerDispatch({ type: 'LOADING' });
+    MiniApp.showBannerAd(bannerAdId)
+      .then(handleBannerSuccess)
+      .catch(handleBannerFailure);
   };
 
   const renderLoading = () => (
@@ -245,6 +273,26 @@ function Ads() {
             text: 'Show Reward',
             disabled: rewardState.isLoading,
             onClick: displayRewardAd,
+          })}
+        </Paper>
+        <Paper className={classes.paper}>
+          {bannerState.isLoading && renderLoading()}
+          {bannerState.error && renderError(bannerState.error)}
+
+          {renderInput({
+            label: 'Banner Ad Id',
+            value: bannerAdId,
+            onChange: setBannerAdId,
+          })}
+          {renderButton({
+            text: 'Load Banner',
+            disabled: bannerState.isLoading,
+            onClick: loadBannerlAd,
+          })}
+          {renderButton({
+            text: 'Show Interstitial',
+            disabled: bannerState.isLoading,
+            onClick: displayBannerAd,
           })}
         </Paper>
       </GreyCard>

--- a/js-miniapp-sample/src/pages/ads.js
+++ b/js-miniapp-sample/src/pages/ads.js
@@ -95,47 +95,58 @@ function Ads() {
     dataFetchReducer,
     initialState
   );
+
   const [rewardState, rewardDispatch] = useReducer(
     dataFetchReducer,
     initialState
   );
+
   const [bannerState, bannerDispatch] = useReducer(
     dataFetchReducer,
     initialState
   );
+
   const [interstitialAdId, setInterstitialAdId] = useState(
     'ca-app-pub-3940256099942544/1033173712'
   );
+
   const [rewardAdId, setRewardAdId] = useState(
     'ca-app-pub-3940256099942544/5224354917'
   );
+
   const [bannerAdId, setBannerAdId] = useState(
     'ca-app-pub-3940256099942544/6300978111'
   );
+
   const classes = useStyles();
 
   const handleInterstitialSuccess = (loadSuccess) => {
     console.log(loadSuccess);
     interstitialDispatch({ type: 'SUCCESS' });
   };
+
   const handleInterstitialFailure = (error) => {
     interstitialDispatch({ type: 'FAILURE', error });
     console.error(error);
   };
+
   const handleBannerSuccess = (loadSuccess) => {
     bannerDispatch({ type: 'SUCCESS' });
     console.log(loadSuccess);
   };
+
   const handleBannerFailure = (error) => {
     bannerDispatch({ type: 'FAILURE', error });
     console.error(error);
   };
+
   const loadInterstitialAd = () => {
     interstitialDispatch({ type: 'LOADING' });
     MiniApp.loadInterstitialAd(interstitialAdId)
       .then(handleInterstitialSuccess)
       .catch(handleInterstitialFailure);
   };
+
   const displayInterstitialAd = () => {
     interstitialDispatch({ type: 'LOADING' });
     MiniApp.showInterstitialAd(interstitialAdId)
@@ -156,6 +167,7 @@ function Ads() {
       })
       .catch(handleRewardFailure);
   };
+
   const displayRewardAd = () => {
     rewardDispatch({ type: 'LOADING' });
     MiniApp.showRewardedAd(rewardAdId)
@@ -165,12 +177,6 @@ function Ads() {
       .catch(handleRewardFailure);
   };
 
-  const loadBannerAd = () => {
-    bannerDispatch({ type: 'LOADING' });
-    MiniApp.loadBannerAd(bannerAdId)
-      .then(handleBannerSuccess)
-      .catch(handleBannerFailure);
-  };
   const displayBannerAd = () => {
     bannerDispatch({ type: 'LOADING' });
     MiniApp.showBannerAd(bannerAdId)
@@ -258,7 +264,6 @@ function Ads() {
                 </Typography>
               </CardContent>
             )}
-
           {renderInput({
             label: 'Rewarded Ad Id',
             value: rewardAdId,
@@ -278,19 +283,13 @@ function Ads() {
         <Paper className={classes.paper}>
           {bannerState.isLoading && renderLoading()}
           {bannerState.error && renderError(bannerState.error)}
-
           {renderInput({
             label: 'Banner Ad Id',
             value: bannerAdId,
             onChange: setBannerAdId,
           })}
           {renderButton({
-            text: 'Load Banner',
-            disabled: bannerState.isLoading,
-            onClick: loadBannerAd,
-          })}
-          {renderButton({
-            text: 'Show Banner',
+            text: 'Show Banner Ad',
             disabled: bannerState.isLoading,
             onClick: displayBannerAd,
           })}

--- a/js-miniapp-sdk/CHANGELOG.md
+++ b/js-miniapp-sdk/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 1.7.0 (In PRogress)
 
-- **Feature:** Added support for requesting the load and display of Banner Ads in Host app. [See here](README.md#Show-Ads).
+- **Feature:** Added support for requesting the display of Banner Ads in Host app. [See here](README.md#Show-Ads).
 
 ### 1.6.1 (2021-01-06)
 

--- a/js-miniapp-sdk/CHANGELOG.md
+++ b/js-miniapp-sdk/CHANGELOG.md
@@ -1,9 +1,11 @@
 ## CHANGELOG
 
 ### 1.7.0 (In progress)
+
 - **Feature:** Added `CustomPermissionName.LOCATION`.
 - **Change:** Updated `requestLocationPermission()` to `requestLocationPermission(permissionDescription?: string)`. From now `requestLocationPermission` will request both custom and device permission respectively. [See here](README.md#Request-Permissions).
 - **Feature:** Added support for requesting Contact list from Host app. [See here](README.md#Requesting-User-details).
+- **Feature:** Added support for requesting the load and display of Banner Ads in Host app. [See here](README.md#Show-Ads).
 
 ### 1.5.0 (2020-11-13)
 
@@ -15,7 +17,7 @@
 
 ### 1.3.0 (2020-10-22)
 
-- **Feature:** Added support for requesting the load and display of Interstitial, Rewarded & Banner Ads in Host app. [See here](README.md#Show-Ads).
+- **Feature:** Added support for requesting the load and display of Interstitial, Rewarded in Host app. [See here](README.md#Show-Ads).
 - **Feature:** Added support for requesting User Name and Profile Photo from Host app. [See here](README.md#Requesting-User-details).
 - **Feature:** Added `MiniApp.getPlatform` for retrieving the platform name of the device. [See here](README.md#check-androidios-device).
 

--- a/js-miniapp-sdk/CHANGELOG.md
+++ b/js-miniapp-sdk/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## CHANGELOG
 
-### 1.6.0 (2020-12-18)
+### 1.7.0 (In progress)
 - **Feature:** Added `CustomPermissionName.LOCATION`.
 - **Change:** Updated `requestLocationPermission()` to `requestLocationPermission(permissionDescription?: string)`. From now `requestLocationPermission` will request both custom and device permission respectively. [See here](README.md#Request-Permissions).
 - **Feature:** Added support for requesting Contact list from Host app. [See here](README.md#Requesting-User-details).
@@ -15,7 +15,7 @@
 
 ### 1.3.0 (2020-10-22)
 
-- **Feature:** Added support for requesting the load and display of Interstitial & Rewarded Ads in Host app. [See here](README.md#4-Show-Ads).
+- **Feature:** Added support for requesting the load and display of Interstitial, Rewarded & Banner Ads in Host app. [See here](README.md#Show-Ads).
 - **Feature:** Added support for requesting User Name and Profile Photo from Host app. [See here](README.md#Requesting-User-details).
 - **Feature:** Added `MiniApp.getPlatform` for retrieving the platform name of the device. [See here](README.md#check-androidios-device).
 

--- a/js-miniapp-sdk/README.md
+++ b/js-miniapp-sdk/README.md
@@ -128,16 +128,19 @@ miniApp.requestCustomPermissions([
 [Ad.loadRewardedAd](api/interfaces/ad.md#loadrewardedad), 
 [Ad.showInterstitialAd](api/interfaces/ad.md#showinterstitialad), 
 [Ad.showRewardedAd](api/interfaces/ad.md#showrewardedad),
-[Reward](api/interfaces/reward.md) 
+[Reward](api/interfaces/reward.md),
+[Ad.loadBannerAd](api/interfaces/ad.md#loadBannerAd),
+[Ad.showBannerAd](api/interfaces/ad.md#showBannerAd)
 
 Mini App SDK allows you to display ads upon requesting from a Mini App with an ad unit id.
 This requires you to first load an Ad by passing an ID. You can then display an Ad in the Ad Unit by passing the same ID which was used for loading.
 
-Note that typically you should load your Ads at some point earlier than you intend to use them, such as at App launch time. You can also pre-load multiple Ads by calling `MiniApp.loadInterstialAd` or `MiniApp.loadRewardedAd` multiple times.
+Note that typically you should load your Ads at some point earlier than you intend to use them, such as at App launch time. You can also pre-load multiple Ads by calling `MiniApp.loadInterstialAd`, `MiniApp.loadRewardedAd` or `MiniApp.loadBannerAd` multiple times.
 
-Currently two ad types are supported,
+Currently three ad types are supported,
 1. Interstitial
 2. Rewarded
+3. Banner
 
 ```javascript
 const adUnitID = 'xxx-xxx-xxxxxxxxxxxxx';
@@ -157,6 +160,18 @@ const adUnitID = 'xxx-xxx-xxxxxxxxxxxxx';
 miniApp.loadRewardedAd(adUnitID)
     .then(response => {
         miniApp.showRewardedAd(adUnitID)
+            .then(response => console.log(response) )
+            .catch( error => console.error(response) );
+    })
+    .catch( error => console.error(response) );
+```
+
+```javascript
+const adUnitID = 'xxx-xxx-xxxxxxxxxxxxx';
+
+miniApp.loadBannerAd(adUnitID)
+    .then(response => {
+        miniApp.showBannerAd(adUnitID)
             .then(response => console.log(response) )
             .catch( error => console.error(response) );
     })

--- a/js-miniapp-sdk/README.md
+++ b/js-miniapp-sdk/README.md
@@ -129,13 +129,12 @@ miniApp.requestCustomPermissions([
 [Ad.showInterstitialAd](api/interfaces/ad.md#showinterstitialad), 
 [Ad.showRewardedAd](api/interfaces/ad.md#showrewardedad),
 [Reward](api/interfaces/reward.md),
-[Ad.loadBannerAd](api/interfaces/ad.md#loadBannerAd),
 [Ad.showBannerAd](api/interfaces/ad.md#showBannerAd)
 
 Mini App SDK allows you to display ads upon requesting from a Mini App with an ad unit id.
 This requires you to first load an Ad by passing an ID. You can then display an Ad in the Ad Unit by passing the same ID which was used for loading.
 
-Note that typically you should load your Ads at some point earlier than you intend to use them, such as at App launch time. You can also pre-load multiple Ads by calling `MiniApp.loadInterstialAd`, `MiniApp.loadRewardedAd` or `MiniApp.loadBannerAd` multiple times.
+Note that typically you should load your Interstitial and Reward Ads at some point earlier than you intend to use them, such as at App launch time. You can also pre-load multiple Ads by calling `MiniApp.loadInterstialAd`, `MiniApp.loadRewardedAd` multiple times.
 
 Currently three ad types are supported,
 1. Interstitial
@@ -169,12 +168,8 @@ miniApp.loadRewardedAd(adUnitID)
 ```javascript
 const adUnitID = 'xxx-xxx-xxxxxxxxxxxxx';
 
-miniApp.loadBannerAd(adUnitID)
-    .then(response => {
-        miniApp.showBannerAd(adUnitID)
-            .then(response => console.log(response) )
-            .catch( error => console.error(response) );
-    })
+miniApp.showBannerAd(adUnitID)
+    .then(response => console.log(response) )
     .catch( error => console.error(response) );
 ```
 

--- a/js-miniapp-sdk/src/miniapp.ts
+++ b/js-miniapp-sdk/src/miniapp.ts
@@ -100,7 +100,7 @@ interface Ad {
 
   /**
    * Shows the Banner Ad for the specified ID.
-   * Promise is resolved after the user closes the Ad.
+   * Promise is resolved after the banner ad is shown.
    * @returns The Promise of successfully appeared response.
    * Promise is rejected if the Ad failed to display wasn't loaded first using MiniApp.loadBannerAd.
    */

--- a/js-miniapp-sdk/src/miniapp.ts
+++ b/js-miniapp-sdk/src/miniapp.ts
@@ -72,6 +72,15 @@ interface MiniAppFeatures {
  */
 interface Ad {
   /**
+   * Loads the specified Banner Ad with Unit ID.
+   * Can be called multiple times to pre-load multiple ads.
+   * Promise is resolved when successfully loaded.
+   * @returns The Promise of load success response.
+   * Promise is rejected if failed to load.
+   */
+  loadBannerAd(id: string): Promise<string>;
+
+  /**
    * Loads the specified Interstittial Ad Unit ID.
    * Can be called multiple times to pre-load multiple ads.
    * Promise is resolved when successfully loaded.
@@ -88,6 +97,14 @@ interface Ad {
    * Promise is rejected if failed to load.
    */
   loadRewardedAd(id: string): Promise<string>;
+
+  /**
+   * Shows the Banner Ad for the specified ID.
+   * Promise is resolved after the user closes the Ad.
+   * @returns The Promise of successfully appeared response.
+   * Promise is rejected if the Ad failed to display wasn't loaded first using MiniApp.loadBannerAd.
+   */
+  showBannerAd(id: string): Promise<string>;
 
   /**
    * Shows the Interstitial Ad for the specified ID.
@@ -204,12 +221,20 @@ export class MiniApp implements MiniAppFeatures, Ad, Platform {
       .then(permissionResult => permissionResult.permissions);
   }
 
+  loadBannerAd(id: string): Promise<string> {
+    return getBridge().loadBannerAd(id);
+  }
+
   loadInterstitialAd(id: string): Promise<string> {
     return getBridge().loadInterstitialAd(id);
   }
 
   loadRewardedAd(id: string): Promise<string> {
     return getBridge().loadRewardedAd(id);
+  }
+
+  showBannerAd(id: string): Promise<string> {
+    return getBridge().showBannerAd(id);
   }
 
   showInterstitialAd(id: string): Promise<string> {

--- a/js-miniapp-sdk/src/miniapp.ts
+++ b/js-miniapp-sdk/src/miniapp.ts
@@ -195,22 +195,22 @@ export class MiniApp implements MiniAppFeatures, Ad, Platform {
     ];
 
     return this.requestCustomPermissions(locationPermission)
-      .then((permission) =>
+      .then(permission =>
         permission.find(
-          (result) =>
+          result =>
             result.status === CustomPermissionStatus.ALLOWED ||
             // Case where older Android SDK doesn't support the Location custom permission
             result.status === CustomPermissionStatus.PERMISSION_NOT_AVAILABLE
         )
       )
-      .catch((error) =>
+      .catch(error =>
         // Case where older iOS SDK doesn't support the Location custom permission
         typeof error === 'string' &&
         error.startsWith('invalidCustomPermissionsList')
           ? Promise.resolve(true)
           : Promise.reject(error)
       )
-      .then((hasPermission) =>
+      .then(hasPermission =>
         hasPermission
           ? this.requestPermission(DevicePermission.LOCATION)
           : Promise.reject('User denied location permission to this mini app.')
@@ -222,9 +222,8 @@ export class MiniApp implements MiniAppFeatures, Ad, Platform {
   ): Promise<CustomPermissionResult[]> {
     return getBridge()
       .requestCustomPermissions(permissions)
-      .then((permissionResult) => permissionResult.permissions);
+      .then(permissionResult => permissionResult.permissions);
   }
-
 
   loadInterstitialAd(id: string): Promise<string> {
     return getBridge().loadInterstitialAd(id);

--- a/js-miniapp-sdk/src/miniapp.ts
+++ b/js-miniapp-sdk/src/miniapp.ts
@@ -73,15 +73,6 @@ interface MiniAppFeatures {
  */
 interface Ad {
   /**
-   * Loads the specified Banner Ad with Unit ID.
-   * Can be called multiple times to pre-load multiple ads.
-   * Promise is resolved when successfully loaded.
-   * @returns The Promise of load success response.
-   * Promise is rejected if failed to load.
-   */
-  loadBannerAd(id: string): Promise<string>;
-
-  /**
    * Loads the specified Interstittial Ad Unit ID.
    * Can be called multiple times to pre-load multiple ads.
    * Promise is resolved when successfully loaded.
@@ -103,7 +94,7 @@ interface Ad {
    * Shows the Banner Ad for the specified ID.
    * Promise is resolved after the banner ad is shown.
    * @returns The Promise of successfully appeared response.
-   * Promise is rejected if the Ad failed to display wasn't loaded first using MiniApp.loadBannerAd.
+   * Promise is rejected if the Ad failed to display MiniApp.showBannerAd.
    */
   showBannerAd(id: string): Promise<string>;
 
@@ -204,22 +195,22 @@ export class MiniApp implements MiniAppFeatures, Ad, Platform {
     ];
 
     return this.requestCustomPermissions(locationPermission)
-      .then(permission =>
+      .then((permission) =>
         permission.find(
-          result =>
+          (result) =>
             result.status === CustomPermissionStatus.ALLOWED ||
             // Case where older Android SDK doesn't support the Location custom permission
             result.status === CustomPermissionStatus.PERMISSION_NOT_AVAILABLE
         )
       )
-      .catch(error =>
+      .catch((error) =>
         // Case where older iOS SDK doesn't support the Location custom permission
         typeof error === 'string' &&
         error.startsWith('invalidCustomPermissionsList')
           ? Promise.resolve(true)
           : Promise.reject(error)
       )
-      .then(hasPermission =>
+      .then((hasPermission) =>
         hasPermission
           ? this.requestPermission(DevicePermission.LOCATION)
           : Promise.reject('User denied location permission to this mini app.')
@@ -231,12 +222,9 @@ export class MiniApp implements MiniAppFeatures, Ad, Platform {
   ): Promise<CustomPermissionResult[]> {
     return getBridge()
       .requestCustomPermissions(permissions)
-      .then(permissionResult => permissionResult.permissions);
+      .then((permissionResult) => permissionResult.permissions);
   }
 
-  loadBannerAd(id: string): Promise<string> {
-    return getBridge().loadBannerAd(id);
-  }
 
   loadInterstitialAd(id: string): Promise<string> {
     return getBridge().loadInterstitialAd(id);

--- a/js-miniapp-sdk/test/miniapp.spec.ts
+++ b/js-miniapp-sdk/test/miniapp.spec.ts
@@ -18,8 +18,10 @@ window.MiniAppBridge = {
   getUniqueId: sinon.stub(),
   requestPermission: sinon.stub(),
   requestCustomPermissions: sinon.stub(),
+  loadBannerAd: sinon.stub(),
   loadInterstitialAd: sinon.stub(),
   loadRewardedAd: sinon.stub(),
+  showBannerAd: sinon.stub(),
   showInterstitialAd: sinon.stub(),
   showRewardedAd: sinon.stub(),
   shareInfo: sinon.stub(),
@@ -93,6 +95,26 @@ describe('requestCustomPermissions', () => {
         status: CustomPermissionStatus.ALLOWED,
       },
     ]);
+  });
+});
+
+describe('showBannerAd', () => {
+  it('should retrieve appeared succcess response for banner ad from the Mini App Bridge', () => {
+    const response = 'appeared';
+
+    const adUnitId = 'xxx-xxx-xxxxxxxxxxxxx';
+
+    window.MiniAppBridge.showBannerAd.resolves(response);
+    return expect(miniApp.showBannerAd(adUnitId)).to.eventually.equal(response);
+  });
+
+  it('should retrive error response from the Mini App Bridge', () => {
+    const error = 'error';
+
+    const adUnitId = 'xxx-xxx-xxxxxxxxxxxxx';
+
+    window.MiniAppBridge.showBannerAd.resolves(error);
+    return expect(miniApp.showBannerAd(adUnitId)).to.eventually.equal(error);
   });
 });
 
@@ -172,6 +194,25 @@ describe('loadInterstitialAd', () => {
     return expect(miniApp.loadInterstitialAd(adUnitId)).to.eventually.equal(
       error
     );
+  });
+});
+
+describe('loadBannerAd', () => {
+  it('should retrieve the load banner ad result from the Mini App Bridge', () => {
+    const adUnitId = 'xxx-xxx-xxxxxxxxxxxxx';
+
+    const response = 'success';
+
+    window.MiniAppBridge.loadBannerAd.resolves(response);
+    return expect(miniApp.loadBannerAd(adUnitId)).to.eventually.equal(response);
+  });
+  it('should retrive error response from the Mini App Bridge once loadBannerAd rejects with error', () => {
+    const adUnitId = 'xxx-xxx-xxxxxxxxxxxxx';
+
+    const error = 'error';
+
+    window.MiniAppBridge.loadBannerAd.resolves(error);
+    return expect(miniApp.loadBannerAd(adUnitId)).to.eventually.equal(error);
   });
 });
 

--- a/js-miniapp-sdk/test/miniapp.spec.ts
+++ b/js-miniapp-sdk/test/miniapp.spec.ts
@@ -24,7 +24,6 @@ window.MiniAppBridge = {
   getUniqueId: sinon.stub(),
   requestPermission: sinon.stub(),
   requestCustomPermissions: sinon.stub(),
-  loadBannerAd: sinon.stub(),
   loadInterstitialAd: sinon.stub(),
   loadRewardedAd: sinon.stub(),
   showBannerAd: sinon.stub(),
@@ -256,24 +255,6 @@ describe('loadInterstitialAd', () => {
   });
 });
 
-describe('loadBannerAd', () => {
-  it('should retrieve the load banner ad result from the Mini App Bridge', () => {
-    const adUnitId = 'xxx-xxx-xxxxxxxxxxxxx';
-
-    const response = 'success';
-
-    window.MiniAppBridge.loadBannerAd.resolves(response);
-    return expect(miniApp.loadBannerAd(adUnitId)).to.eventually.equal(response);
-  });
-  it('should retrive error response from the Mini App Bridge once loadBannerAd rejects with error', () => {
-    const adUnitId = 'xxx-xxx-xxxxxxxxxxxxx';
-
-    const error = 'error';
-
-    window.MiniAppBridge.loadBannerAd.resolves(error);
-    return expect(miniApp.loadBannerAd(adUnitId)).to.eventually.equal(error);
-  });
-});
 
 describe('loadRewardedAd', () => {
   it('should retrieve the load result from the Mini App Bridge', () => {

--- a/js-miniapp-sdk/test/miniapp.spec.ts
+++ b/js-miniapp-sdk/test/miniapp.spec.ts
@@ -255,7 +255,6 @@ describe('loadInterstitialAd', () => {
   });
 });
 
-
 describe('loadRewardedAd', () => {
   it('should retrieve the load result from the Mini App Bridge', () => {
     const adUnitId = 'xxx-xxx-xxxxxxxxxxxxx';


### PR DESCRIPTION
# Description
This PR is to show Banner ads in Mobile SDK requested from Mini apps
`showBannerAd` method is created in both bridge and js SDK to support to show banner ads.
Initially, the idea is to show banner ads at the bottom of the web view, as discussed in the corresponding ticket.
While designing the functions `SMART_BANNER ` was kept in consideration.

Further development is possible I guess with the use of Adaptive banners, where I think dimensions can be passed as an argument to load user-defined banner sizes.

Initial banner placement and size idea is below,
<img width="317" alt="Screen Shot 2020-12-21 at 13 57 17" src="https://user-images.githubusercontent.com/67311553/103061745-a9035400-45ef-11eb-81d5-0a6051c858d4.png">

## Links
https://jira.rakuten-it.com/jira/browse/MINIBUILD-719

# Checklist
- [X] I wrote/updated tests for new/changed code.
- [X] I ran `yarn sdk buildSdk` and `yarn bridge buildBridge` without issues.
- [X] I ran `yarn sample prettify` and `yarn sample build` without issues.
