### PR TITLE
Fixes for location permission request

### DIFF
--- a/js-miniapp-sample/src/hooks/useGeoLocation.js
+++ b/js-miniapp-sample/src/hooks/useGeoLocation.js
@@ -30,7 +30,12 @@ const useGeoLocation = () => {
           }
         )
       )
-      .catch((error) => console.error(error));
+      .catch((error) =>
+        setState({
+          isWatching: false,
+          error,
+        })
+      );
   };
 
   const unwatch = () => {

--- a/js-miniapp-sample/src/pages/web-location.js
+++ b/js-miniapp-sample/src/pages/web-location.js
@@ -59,6 +59,8 @@ const Location = (props: any) => {
   return (
     <GreyCard>
       <CardContent className={classes.content}>
+        {state.error && <div>Error: {state.error}</div>}
+
         {state.location && state.isWatching && (
           <div
             className={classes.locationContainer}

--- a/js-miniapp-sdk/CHANGELOG.md
+++ b/js-miniapp-sdk/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 1.X.X (In progress)
 - **Fix:** Location permission support for iOS/Android Mini App SDK 2.6 and below.
+- **Fix:** Reject promise from `MiniApp.requestLocationPermission` when the user denies location custom permission.
 
 ### 1.6.0 (2020-12-18)
 - **Feature:** Added `CustomPermissionName.LOCATION`.

--- a/js-miniapp-sdk/CHANGELOG.md
+++ b/js-miniapp-sdk/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## CHANGELOG
 
-### 1.X.X (In progress)
+### 1.6.1 (2021-01-06)
 - **Fix:** Location permission support for iOS/Android Mini App SDK 2.6 and below.
 - **Fix:** Reject promise from `MiniApp.requestLocationPermission` when the user denies location custom permission.
 

--- a/js-miniapp-sdk/CHANGELOG.md
+++ b/js-miniapp-sdk/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## CHANGELOG
 
+### 1.X.X (In progress)
+- **Fix:** Location permission support for iOS/Android Mini App SDK 2.6 and below.
+
 ### 1.6.0 (2020-12-18)
 - **Feature:** Added `CustomPermissionName.LOCATION`.
 - **Change:** Updated `requestLocationPermission()` to `requestLocationPermission(permissionDescription?: string)`. From now `requestLocationPermission` will request both custom and device permission respectively. [See here](README.md#Request-Permissions).

--- a/js-miniapp-sdk/src/miniapp.ts
+++ b/js-miniapp-sdk/src/miniapp.ts
@@ -188,8 +188,18 @@ export class MiniApp implements MiniAppFeatures, Ad, Platform {
     return this.requestCustomPermissions(locationPermission)
       .then(permission =>
         permission.find(
-          result => result.status === CustomPermissionStatus.ALLOWED
+          result =>
+            result.status === CustomPermissionStatus.ALLOWED ||
+            // Case where older Android SDK doesn't support the Location custom permission
+            result.status === CustomPermissionStatus.PERMISSION_NOT_AVAILABLE
         )
+      )
+      .catch(error =>
+        // Case where older iOS SDK doesn't support the Location custom permission
+        typeof error === 'string' &&
+        error.startsWith('invalidCustomPermissionsList')
+          ? Promise.resolve(true)
+          : Promise.reject(error)
       )
       .then(hasPermission =>
         hasPermission ? this.requestPermission(DevicePermission.LOCATION) : null

--- a/js-miniapp-sdk/src/miniapp.ts
+++ b/js-miniapp-sdk/src/miniapp.ts
@@ -35,6 +35,7 @@ interface MiniAppFeatures {
    * and the custom permission for location {@link CustomPermissionName.LOCATION}.
    * @param permissionDescription Description of location permission.
    * @returns The Promise of permission result of mini app from injected side.
+   * Rejects the promise if the user denied the location permission (either the device permission or custom permission).
    */
   requestLocationPermission(permissionDescription?: string): Promise<string>;
 
@@ -202,7 +203,9 @@ export class MiniApp implements MiniAppFeatures, Ad, Platform {
           : Promise.reject(error)
       )
       .then(hasPermission =>
-        hasPermission ? this.requestPermission(DevicePermission.LOCATION) : null
+        hasPermission
+          ? this.requestPermission(DevicePermission.LOCATION)
+          : Promise.reject('User denied location permission to this mini app.')
       );
   }
 

--- a/js-miniapp-sdk/test/miniapp.spec.ts
+++ b/js-miniapp-sdk/test/miniapp.spec.ts
@@ -78,15 +78,28 @@ describe('requestLocationPermission', () => {
   });
 
   it('should request location custom permission', () => {
-    return miniApp.requestLocationPermission('test_description')
-      .then(() => {
-        sinon.assert.calledWith(window.MiniAppBridge.requestCustomPermissions, [
-          {
-            name: CustomPermissionName.LOCATION,
-            description: 'test_description',
-          },
-        ]);
-      })
+    return miniApp.requestLocationPermission('test_description').then(() => {
+      sinon.assert.calledWith(window.MiniAppBridge.requestCustomPermissions, [
+        {
+          name: CustomPermissionName.LOCATION,
+          description: 'test_description',
+        },
+      ]);
+    });
+  });
+
+  it('should reject when user denies location custom permission', () => {
+    window.MiniAppBridge.requestCustomPermissions.resolves({
+      permissions: [
+        {
+          name: CustomPermissionName.LOCATION,
+          status: CustomPermissionStatus.DENIED,
+        },
+      ],
+    });
+
+    return expect(miniApp.requestLocationPermission('test_description')).to.be
+      .rejected;
   });
 
   it('should handle case where Android SDK does not support location custom permission', () => {


### PR DESCRIPTION
# Description
- fix: Location permission support for older iOS/Android SDK
  - The Location custom permission doesn't exist on the iOS/Android SDK < 2.7.0, so requestLocationPermission was failing to request the device permission on those versions.
- fix: Reject promise when location custom permission is denied
- feat: (sample) Display error messages on location screen

## Links
MINI-2450
MINI-2479

# Checklist
- [x] I wrote/updated tests for new/changed code.
- [x] I ran `yarn sdk buildSdk` and `yarn bridge buildBridge` without issues.
- [x] I ran `yarn sample prettify` and `yarn sample build` without issues.
