### PR TITLE
bugfix: print parameters in sample app when the character starts with hash 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ jsconfig.json
 #Exclude tsc generated files
 js/*.map
 js/ts.js
+
+_site/

--- a/js-miniapp-sample/src/pages/landing.js
+++ b/js-miniapp-sample/src/pages/landing.js
@@ -37,7 +37,7 @@ const Landing = () => {
         <p>Demo Mini App JS SDK</p>
         <p className={classes.info}>Platform: {MiniApp.getPlatform()}</p>
         <p className={classes.info}>
-          Parameters: {window.location.search || 'None'}
+          Parameters: {window.location.search + window.location.hash || 'None'}
         </p>
       </CardContent>
     </GreyCard>


### PR DESCRIPTION
# Description
Append characters starts with `#` in Paramteers in sample app.

## Links
- MINI-2504

# Checklist
- [ ] I wrote/updated tests for new/changed code.
- [x] I ran `yarn sdk buildSdk` and `yarn bridge buildBridge` without issues.
- [x] I ran `yarn sample prettify` and `yarn sample build` without issues.
