### PR TITLE
ui bugfix: sample app is showing truncated parameter list

### DIFF
--- a/js-miniapp-sample/src/pages/landing.js
+++ b/js-miniapp-sample/src/pages/landing.js
@@ -25,6 +25,7 @@ const useStyles = makeStyles((theme) => ({
   info: {
     fontSize: 16,
     lineBreak: 'anywhere',
+    wordBreak: 'break-all',
     marginTop: 0,
   },
 }));


### PR DESCRIPTION
# Description
Sample app is truncating long parameter while displaying. We can break the word by this PR.

## Links
- MINI-2532

# Checklist
- [ ] I wrote/updated tests for new/changed code.
- [x] I ran `yarn sdk buildSdk` and `yarn bridge buildBridge` without issues.
- [x] I ran `yarn sample prettify` and `yarn sample build` without issues.
