### PR TITLE
fix few typo issues

### DIFF
--- a/js-miniapp-bridge/src/android/android-bridge.ts
+++ b/js-miniapp-bridge/src/android/android-bridge.ts
@@ -9,7 +9,7 @@ import { Platform } from '../types/platform';
 /* tslint:disable:no-any */
 let uniqueId = Math.random();
 
-class AndroidExcecutor implements PlatformExecutor {
+class AndroidExecutor implements PlatformExecutor {
   exec(action, param, onSuccess, onError) {
     const callback = {} as Callback;
     callback.onSuccess = onSuccess;
@@ -27,4 +27,4 @@ class AndroidExcecutor implements PlatformExecutor {
   }
 }
 
-(window as any).MiniAppBridge = new MiniAppBridge(new AndroidExcecutor());
+(window as any).MiniAppBridge = new MiniAppBridge(new AndroidExecutor());

--- a/js-miniapp-bridge/src/common-bridge.ts
+++ b/js-miniapp-bridge/src/common-bridge.ts
@@ -116,7 +116,7 @@ export class MiniAppBridge {
 
   /**
    * Associating requestPermission function to MiniAppBridge object.
-   * @param {DevicePermission} permissionType Type of permission that is requested. For eg., location
+   * @param {DevicePermission} permissionType Type of permission that is requested e.g. location
    */
   requestPermission(permissionType: DevicePermission) {
     return new Promise<string>((resolve, reject) => {
@@ -148,7 +148,7 @@ export class MiniAppBridge {
    * Associating loadInterstitialAd function to MiniAppBridge object.
    * This function preloads interstitial ad before they are requested for display.
    * Can be called multiple times to pre-load multiple ads.
-   * @param {string} id ad unit id of the intertitial ad that needs to be loaded.
+   * @param {string} id ad unit id of the interstitial ad that needs to be loaded.
    */
   loadInterstitialAd(id: string) {
     return new Promise<string>((resolve, reject) => {
@@ -334,9 +334,9 @@ export class MiniAppBridge {
 }
 
 /**
- * Method to remove the callback object from the message queue after successfull/error communication
+ * Method to remove the callback object from the message queue after successful/error communication
  * with the native application
- * @param  {[Object]} queueObj Queue Object that holds the references of callback informations
+ * @param  {[Object]} queueObj Queue Object that holds the references of callback information
  *
  * @internal
  */

--- a/js-miniapp-bridge/src/ios/ios-bridge.ts
+++ b/js-miniapp-bridge/src/ios/ios-bridge.ts
@@ -16,7 +16,7 @@ const GeolocationPositionError = {
   TIMEOUT: 3,
 };
 
-class IOSExcecutor implements PlatformExecutor {
+class IOSExecutor implements PlatformExecutor {
   exec(action, param, onSuccess, onError) {
     const callback = {} as Callback;
     callback.onSuccess = onSuccess;
@@ -34,11 +34,11 @@ class IOSExcecutor implements PlatformExecutor {
   }
 }
 
-const iOSExcecutor = new IOSExcecutor();
-(window as any).MiniAppBridge = new MiniAppBridge(iOSExcecutor);
+const iOSExecutor = new IOSExecutor();
+(window as any).MiniAppBridge = new MiniAppBridge(iOSExecutor);
 
 navigator.geolocation.getCurrentPosition = (success, error, options) => {
-  return iOSExcecutor.exec(
+  return iOSExecutor.exec(
     'getCurrentPosition',
     { locationOptions: options },
     value => {

--- a/js-miniapp-sample/external-webview/index.html
+++ b/js-miniapp-sample/external-webview/index.html
@@ -65,10 +65,10 @@
         <h3>Return To Mini App</h3>
         <br />
         <div>
-            <label>Params to send mini app:</label>
+            <label>Params to send to mini app:</label>
             <br />
             <input id="ReturnInput" 
-                placeholder="Enter params to send Mini App"
+                placeholder="Enter params to send to Mini App"
                 value="?testParam=someValue&test2=anotherValue" 
                 style="width: 250px;" />
             <br />

--- a/js-miniapp-sample/src/hooks/useGeoLocation.test.js
+++ b/js-miniapp-sample/src/hooks/useGeoLocation.test.js
@@ -6,7 +6,7 @@ import useGeoLocation from './useGeoLocation';
 
 describe('useGeoLocation', () => {
   let result;
-  const dummyCoOridinates = {
+  const dummyCoOrdinates = {
     latitude: 51.1,
     longitude: 45.3,
   };
@@ -16,7 +16,7 @@ describe('useGeoLocation', () => {
     getCurrentPosition: jest.fn().mockImplementation((success) =>
       Promise.resolve(
         success({
-          coords: dummyCoOridinates,
+          coords: dummyCoOrdinates,
         })
       )
     ),
@@ -41,7 +41,7 @@ describe('useGeoLocation', () => {
     [state] = result.current;
 
     expect(state.isWatching).toEqual(true);
-    expect(state.location).toEqual(dummyCoOridinates);
+    expect(state.location).toEqual(dummyCoOrdinates);
   });
 
   test('should not watch location when permission not granted', async () => {
@@ -52,7 +52,7 @@ describe('useGeoLocation', () => {
     [state] = result.current;
 
     expect(state.isWatching).toEqual(false);
-    expect(state.location).not.toEqual(dummyCoOridinates);
+    expect(state.location).not.toEqual(dummyCoOrdinates);
   });
 
   test('should stop watching location coordinates', async () => {
@@ -60,7 +60,7 @@ describe('useGeoLocation', () => {
     await act(() => watch());
     [state] = result.current;
     expect(state.isWatching).toEqual(true);
-    expect(state.location).toEqual(dummyCoOridinates);
+    expect(state.location).toEqual(dummyCoOrdinates);
     act(() => unwatch());
     [state] = result.current;
     expect(state.isWatching).toEqual(false);

--- a/js-miniapp-sample/src/hooks/useGeoLocation.test.js
+++ b/js-miniapp-sample/src/hooks/useGeoLocation.test.js
@@ -6,7 +6,7 @@ import useGeoLocation from './useGeoLocation';
 
 describe('useGeoLocation', () => {
   let result;
-  const dummyCoOrdinates = {
+  const dummyCoordinates = {
     latitude: 51.1,
     longitude: 45.3,
   };
@@ -16,7 +16,7 @@ describe('useGeoLocation', () => {
     getCurrentPosition: jest.fn().mockImplementation((success) =>
       Promise.resolve(
         success({
-          coords: dummyCoOrdinates,
+          coords: dummyCoordinates,
         })
       )
     ),
@@ -41,7 +41,7 @@ describe('useGeoLocation', () => {
     [state] = result.current;
 
     expect(state.isWatching).toEqual(true);
-    expect(state.location).toEqual(dummyCoOrdinates);
+    expect(state.location).toEqual(dummyCoordinates);
   });
 
   test('should not watch location when permission not granted', async () => {
@@ -52,7 +52,7 @@ describe('useGeoLocation', () => {
     [state] = result.current;
 
     expect(state.isWatching).toEqual(false);
-    expect(state.location).not.toEqual(dummyCoOrdinates);
+    expect(state.location).not.toEqual(dummyCoordinates);
   });
 
   test('should stop watching location coordinates', async () => {
@@ -60,7 +60,7 @@ describe('useGeoLocation', () => {
     await act(() => watch());
     [state] = result.current;
     expect(state.isWatching).toEqual(true);
-    expect(state.location).toEqual(dummyCoOrdinates);
+    expect(state.location).toEqual(dummyCoordinates);
     act(() => unwatch());
     [state] = result.current;
     expect(state.isWatching).toEqual(false);


### PR DESCRIPTION
# Description
- Change the text to "param to send to mini app".
- Fix few typo issues 

## Links
- MINI-2589

# Checklist
- [ ] I wrote/updated tests for new/changed code.
- [x] I ran `yarn sdk buildSdk` and `yarn bridge buildBridge` without issues.
- [x] I ran `yarn sample prettify` and `yarn sample build` without issues.
