### PR TITLE
Code-cov updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,10 +50,14 @@ jobs:
       - run:
           name: Compile
           command: yarn bridge compile
+      - run:
+          name: code coverage
+          command: yarn bridge coverage
       - persist_to_workspace:
           root: ~/mini-js-bridge
           paths:
             - js-miniapp-bridge/build/
+            - js-miniapp-bridge/coverage/
 
   export-bridge:
     working_directory: ~/mini-js-bridge
@@ -100,9 +104,6 @@ jobs:
       - run: # run coverage report
           name: code coverage
           command: yarn sdk coverage
-      - run: # upload coverage report
-          name: upload coverage
-          command: bash <(curl -s https://codecov.io/bash)
       - store_artifacts: # special step to save test results as as artifact
           # Upload test summary for display in Artifacts
           path: js-miniapp-sdk/test-results/
@@ -123,6 +124,7 @@ jobs:
           paths:
             - js-miniapp-sdk/build/
             - js-miniapp-sdk/publishableDocs/
+            - js-miniapp-sdk/coverage/
 
   publish-sdk:
     working_directory: ~/mini-js-sdk
@@ -232,6 +234,18 @@ jobs:
               echo "Nothing to commit"
             fi
 
+  upload-coverage:
+    working_directory: ~/js-miniapp
+    docker:
+      - image: circleci/node:10.16.3
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ./
+      - run:
+          name: upload coverage
+          command: bash <(curl -s https://codecov.io/bash)
+
 workflows:
   version: 2
   build-and-release:
@@ -273,3 +287,7 @@ workflows:
           filters:
             branches:
               only: master
+      - upload-coverage:
+          requires:
+           - build-sdk
+           - build-bridge

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![npm version](https://img.shields.io/npm/v/js-miniapp-sdk.svg?style=flat)](https://www.npmjs.com/package/js-miniapp-sdk)
 [![CircleCI](https://circleci.com/gh/rakutentech/js-miniapp.svg?style=svg)](https://circleci.com/gh/rakutentech/js-miniapp)
+[![codecov](https://codecov.io/gh/rakutentech/js-miniapp/branch/master/graph/badge.svg?token=JG77H8JRSK)](https://codecov.io/gh/rakutentech/js-miniapp)
 [![Code Style: Google](https://img.shields.io/badge/code%20style-google-blueviolet.svg)](https://github.com/google/gts)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 


### PR DESCRIPTION
# Description
- docs: Add code-cov badge to readme
- ci: Upload code coverage for js-miniapp-bridge

Also, I noticed that CI wasn't uploading coverage to the correct Code-Cov project, so we weren't getting any reports on `master`. I've fixed that so we should get reports on `master` now: https://app.codecov.io/gh/rakutentech/js-miniapp/branch/master

# Checklist
- [x] I wrote/updated tests for new/changed code.
- [x] I ran `yarn sdk buildSdk` and `yarn bridge buildBridge` without issues.
- [x] I ran `yarn sample prettify` and `yarn sample build` without issues.
