### PR TITLE
bridge & sdk: send message to specific contact

### DIFF
--- a/js-miniapp-bridge/src/common-bridge.ts
+++ b/js-miniapp-bridge/src/common-bridge.ts
@@ -321,16 +321,22 @@ export class MiniAppBridge {
   }
 
   /**
+   * @param id The id of the contact receiving a message. It is possible to put null value when there is no specific contact to send.
    * @param message The message to send to contact.
    * @returns Promise resolves with the Unique ID which was sent the message.
    * Can also resolve with empty (undefined) response in the case that the message was not sent to a contact, such as if the user cancelled sending the message.
    * Promise rejects in the case that there was an error.
    */
-  sendMessageToContact(message: MessageToContact) {
+  sendMessageToContact(id: string, message: MessageToContact) {
+    let customParam = { contactId: id, messageToContact: message } as {};
+    if (id === null || id === undefined) {
+      customParam = { messageToContact: message };
+    }
+
     return new Promise<string | undefined>((resolve, reject) => {
       return this.executor.exec(
         'sendMessageToContact',
-        { messageToContact: message },
+        customParam,
         messageId => resolve(messageId),
         error => reject(error)
       );

--- a/js-miniapp-bridge/src/common-bridge.ts
+++ b/js-miniapp-bridge/src/common-bridge.ts
@@ -321,22 +321,33 @@ export class MiniAppBridge {
   }
 
   /**
-   * @param id The id of the contact receiving a message. It is possible to put null value when there is no specific contact to send.
    * @param message The message to send to contact.
-   * @returns Promise resolves with the Unique ID which was sent the message.
+   * @returns Promise resolves with the contact id received a message.
    * Can also resolve with empty (undefined) response in the case that the message was not sent to a contact, such as if the user cancelled sending the message.
    * Promise rejects in the case that there was an error.
    */
-  sendMessageToContact(id: string, message: MessageToContact) {
-    let customParam = { contactId: id, messageToContact: message } as {};
-    if (id === null || id === undefined) {
-      customParam = { messageToContact: message };
-    }
-
+  sendMessageToContact(message: MessageToContact) {
     return new Promise<string | undefined>((resolve, reject) => {
       return this.executor.exec(
         'sendMessageToContact',
-        customParam,
+        { messageToContact: message },
+        messageId => resolve(messageId),
+        error => reject(error)
+      );
+    });
+  }
+
+  /**
+   * @param id The id of the contact receiving a message.
+   * @param message The message to send to contact.
+   * @returns Promise resolves with the contact id received a message.
+   * @see {sendMessageToContact}
+   */
+  sendMessageToContactId(id: string, message: MessageToContact) {
+    return new Promise<string | undefined>((resolve, reject) => {
+      return this.executor.exec(
+        'sendMessageToContact',
+        { contactId: id, messageToContact: message },
         messageId => resolve(messageId),
         error => reject(error)
       );

--- a/js-miniapp-sample/src/pages/message.js
+++ b/js-miniapp-sample/src/pages/message.js
@@ -99,10 +99,10 @@ const Message = (props: MessageTypeProps) => {
           message.action.trim() ?? '',
           message.title.trim() ?? ''
         )
-        .then((messageId) =>
+        .then((contactId) =>
           setMessageResponse({
             show: true,
-            response: 'Message Id: ' + messageId,
+            response: 'Contact Id: ' + contactId,
           })
         );
     }

--- a/js-miniapp-sdk/README.md
+++ b/js-miniapp-sdk/README.md
@@ -370,13 +370,25 @@ miniApp.setScreenOrientation(ScreenOrientation.LOCK_LANDSCAPE) // or LOCK_PORTRA
 ### Send message
 
 **API:** [ChatServiceProvider](api/interfaces/chatserviceprovider.md)
+[MessageToContact](api/interfaces/messagetocontact.md)
 
 #### Send message to the single contact
 
 ```javascript
-miniApp.chatService.sendMessageToContact()
-    .then(messageId => {
-		console.log(messageId);
+miniApp.chatService.sendMessageToContact(messageToContact)
+    .then(contactId => {
+		console.log(contactId);
+	}).catch(error => {
+		console.error(error);
+	});
+```
+
+#### Send message by contact id
+
+```javascript
+miniApp.chatService.sendMessageToContactId(id, messageToContact)
+    .then(contactId => {
+		console.log(contactId);
 	}).catch(error => {
 		console.error(error);
 	});

--- a/js-miniapp-sdk/src/modules/chat-service.ts
+++ b/js-miniapp-sdk/src/modules/chat-service.ts
@@ -6,16 +6,35 @@ interface ChatServiceProvider {
    * Opens a contact chooser which allows the user to choose a single contact,
    * and then sends the message to the chosen contact.
    * @param message The message to send to contact.
-   * @returns Promise resolves with the Unique ID which was sent the message.
+   * @returns Promise resolves with the contact id received a message.
    * Can also resolve with empty (undefined) response in the case that the message was not sent to a contact, such as if the user cancelled sending the message.
    * Promise rejects in the case that there was an error.
    */
   sendMessageToContact(message: MessageToContact): Promise<string | undefined>;
+
+  /**
+   * Send a message to the specific contact.
+   * @param id The id of the contact receiving a message.
+   * @param message The message to send to contact.
+   * @returns Promise resolves with the contact id received a message.
+   * @see {sendMessageToContact}
+   */
+  sendMessageToContactId(
+    id: string,
+    message: MessageToContact
+  ): Promise<string | undefined>;
 }
 
 /** @internal */
 export class ChatService {
   sendMessageToContact(message: MessageToContact): Promise<string | undefined> {
     return getBridge().sendMessageToContact(message);
+  }
+
+  sendMessageToContactId(
+    id: string,
+    message: MessageToContact
+  ): Promise<string | undefined> {
+    return getBridge().sendMessageToContactId(id, message);
   }
 }

--- a/js-miniapp-sdk/test/miniapp.spec.ts
+++ b/js-miniapp-sdk/test/miniapp.spec.ts
@@ -37,6 +37,7 @@ window.MiniAppBridge = {
   getAccessToken: sandbox.stub(),
   setScreenOrientation: sandbox.stub(),
   sendMessageToContact: sandbox.stub(),
+  sendMessageToContactId: sandbox.stub(),
 };
 const miniApp = new MiniApp();
 const messageToContact: MessageToContact = {
@@ -357,8 +358,13 @@ describe('sendMessage', () => {
     const response = '';
 
     window.MiniAppBridge.sendMessageToContact.resolves(response);
-    return expect(
+    expect(
       miniApp.chatService.sendMessageToContact(messageToContact)
+    ).to.eventually.equal(response);
+
+    window.MiniAppBridge.sendMessageToContactId.resolves(response);
+    return expect(
+      miniApp.chatService.sendMessageToContactId('test_contact_id', messageToContact)
     ).to.eventually.equal(response);
   });
 
@@ -366,8 +372,13 @@ describe('sendMessage', () => {
     const response = undefined;
 
     window.MiniAppBridge.sendMessageToContact.resolves(response);
-    return expect(
+    expect(
       miniApp.chatService.sendMessageToContact(messageToContact)
     ).to.eventually.equal(response);
+
+    window.MiniAppBridge.sendMessageToContactId.resolves(null);
+    return expect(
+      miniApp.chatService.sendMessageToContactId('test_contact_id', messageToContact)
+    ).to.eventually.equal(null);
   });
 });

--- a/js-miniapp-sdk/test/miniapp.spec.ts
+++ b/js-miniapp-sdk/test/miniapp.spec.ts
@@ -364,7 +364,10 @@ describe('sendMessage', () => {
 
     window.MiniAppBridge.sendMessageToContactId.resolves(response);
     return expect(
-      miniApp.chatService.sendMessageToContactId('test_contact_id', messageToContact)
+      miniApp.chatService.sendMessageToContactId(
+        'test_contact_id',
+        messageToContact
+      )
     ).to.eventually.equal(response);
   });
 
@@ -378,7 +381,10 @@ describe('sendMessage', () => {
 
     window.MiniAppBridge.sendMessageToContactId.resolves(null);
     return expect(
-      miniApp.chatService.sendMessageToContactId('test_contact_id', messageToContact)
+      miniApp.chatService.sendMessageToContactId(
+        'test_contact_id',
+        messageToContact
+      )
     ).to.eventually.equal(null);
   });
 });


### PR DESCRIPTION
# Description
- Bridge/SDK: Support send message by contact id.
- Sample: 
Change the response context to retrieve contact id, not message id.
This PR does not have Sample app for Support send message by contact id.

## Links
MINI-2475

# Checklist
- [x] I wrote/updated tests for new/changed code.
- [x] I ran `yarn sdk buildSdk` and `yarn bridge buildBridge` without issues.
- [x] I ran `yarn sample prettify` and `yarn sample build` without issues.
