### PR TITLE
fix: (sample) Changes to ad id inputs were not being saved to state

### DIFF
--- a/js-miniapp-sample/src/pages/ads.js
+++ b/js-miniapp-sample/src/pages/ads.js
@@ -169,7 +169,7 @@ function Ads() {
         label={label}
         className={classes.textfield}
         value={value}
-        onChange={(e) => onChange.call(e.currentTarget.value)}
+        onChange={(e) => onChange.call(null, e.currentTarget.value)}
         variant="outlined"
         color="primary"
         inputProps={{

--- a/js-miniapp-sample/src/pages/file-upload.js
+++ b/js-miniapp-sample/src/pages/file-upload.js
@@ -77,7 +77,7 @@ const FileUploader = () => {
               <TableRow>
                 <TableCell>Name</TableCell>
                 <TableCell align="left">Type</TableCell>
-                <TableCell align="right">Size(KB)</TableCell>
+                <TableCell align="right">Size(Bytes)</TableCell>
                 <TableCell align="right"></TableCell>
               </TableRow>
             </TableHead>


### PR DESCRIPTION
# Description
The `.call` method is supposed to be passed the `this` context as the first parameter.

Also fixed a label issue on the "File Upload" screen - change "KB" to "Bytes".

# Checklist
- [ ] I wrote/updated tests for new/changed code.
- [x] I ran `yarn sdk buildSdk` and `yarn bridge buildBridge` without issues.
- [x] I ran `yarn sample prettify` and `yarn sample build` without issues.
