### PR TITLE
fix: (sample) Long unique ids were not fully visible

### DIFF
--- a/js-miniapp-sample/src/pages/uuid-sdk.js
+++ b/js-miniapp-sample/src/pages/uuid-sdk.js
@@ -21,6 +21,7 @@ const useStyles = makeStyles((theme) => ({
     fontSize: 18,
     color: theme.color.primary,
     fontWeight: 'bold',
+    wordBreak: 'break-word',
   },
   actions: {
     justifyContent: 'center',


### PR DESCRIPTION
# Description
Changed the layout so that it will allow a line break in the middle of the ID

<img width="359" alt="Screen Shot 2021-06-08 at 4 07 44 PM" src="https://user-images.githubusercontent.com/15662659/121139391-afbb1600-c873-11eb-9d7e-53f2bd5ef42f.png">

## Links
MINI-1778

# Checklist
- [x] I wrote/updated tests for new/changed code.
- [x] I ran `yarn sdk buildSdk` and `yarn bridge buildBridge` without issues.
- [x] I ran `yarn sample prettify` and `yarn sample build` without issues.

