### PR TITLE
fix: (sdk) Add quotes around version in docs generation script

### DIFF
--- a/js-miniapp-sdk/scripts/docs.sh
+++ b/js-miniapp-sdk/scripts/docs.sh
@@ -12,7 +12,7 @@ echo "version_base: $DIR_VERSIONS"
 FILE_VERSION_MD="$DIR_VERSIONS/${PACKAGE_VERSION}.md"
 mkdir -p "${FILE_VERSION_MD%/*}" && touch "$FILE_VERSION_MD"
 contents="---
-version: "$PACKAGE_VERSION"
+version: \"$PACKAGE_VERSION\"
 ---"
 cat <<< "$contents" > "$FILE_VERSION_MD"
 


### PR DESCRIPTION
# Description
This fixes an issue where the version name isn't displayed correctly in the dropdown  in the generated docs.

# Checklist
- [x] I wrote/updated tests for new/changed code.
- [x] I ran `yarn sdk buildSdk` and `yarn bridge buildBridge` without issues.
- [x] I ran `yarn sample prettify` and `yarn sample build` without issues.
