### PR TITLE
fix: (sdk) Add date to docs version file to fix list order

### DIFF
--- a/js-miniapp-sdk/scripts/docs.sh
+++ b/js-miniapp-sdk/scripts/docs.sh
@@ -2,7 +2,7 @@
 
 # Get SDK version as X.X (remove fix version)
 PACKAGE_VERSION=$(node -p "require('./package.json').version" | sed -e 's/\.[0-9]*$//')
-echo "version: $PACKAGE_VERSION"
+DATE=$(date +%Y-%m-%d)
 
 DIR_DOCS="publishableDocs/docs/$PACKAGE_VERSION"
 DIR_VERSIONS="publishableDocs/_versions/$PACKAGE_VERSION"
@@ -13,8 +13,13 @@ FILE_VERSION_MD="$DIR_VERSIONS/${PACKAGE_VERSION}.md"
 mkdir -p "${FILE_VERSION_MD%/*}" && touch "$FILE_VERSION_MD"
 contents="---
 version: \"$PACKAGE_VERSION\"
+date: $DATE
 ---"
 cat <<< "$contents" > "$FILE_VERSION_MD"
+
+echo "Created version file: $FILE_VERSION_MD
+$contents
+"
 
 # Generate docs
 npx typedoc --out $DIR_DOCS/api src --options typedoc.json


### PR DESCRIPTION
# Description
This fixes an issue where the versions in the documentation displayed in the wrong order when the version is greater than X.10

## Links
MINI-3425

# Checklist
- [x] I wrote/updated tests for new/changed code.
- [x] I ran `yarn sdk buildSdk` and `yarn bridge buildBridge` without issues.
- [x] I ran `yarn sample prettify` and `yarn sample build` without issues.
