### PR TITLE
Update codeowners to use Mini App SDK team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,3 @@
 # See https://help.github.com/en/articles/about-code-owners
 
-@Climbatize @corycaywood @khairul-alam-licon @munir-rakuten @rleojoseph
-
-js-miniapp-sample/* @suprj @rajesh-sundaram @mohanadwalo @nathan-rakuten
+@rakutentech/miniapp-sdk


### PR DESCRIPTION
# Description
Use `miniapp-sdk` team as the codeowner for this repo. This should be easier to manage than updating the codeowners file

# Checklist
- [x] I wrote/updated tests for new/changed code.
- [x] I ran `yarn sdk buildSdk` and `yarn bridge buildBridge` without issues.
- [x] I ran `yarn sample prettify` and `yarn sample build` without issues.
