### PR TITLE
fix: (sample) Issue with parsing fragment in callback uri

### DIFF
--- a/js-miniapp-sample/src/pages/uri-schemes.js
+++ b/js-miniapp-sample/src/pages/uri-schemes.js
@@ -66,11 +66,13 @@ const UriSchemes = () => {
       return;
     }
 
-    const paramsWithCallback = params
-      .concat(params ? '&' : '?')
+    var url = new URL(EXTERNAL_WEBVIEW_URL + params);
+
+    url.search = url.search
+      .concat(url.search ? '&' : '?')
       .concat(`callbackUrl=${encodeURIComponent(callbackUrl)}`);
 
-    window.location.href = EXTERNAL_WEBVIEW_URL + paramsWithCallback;
+    window.location.href = url;
   }
 
   return (


### PR DESCRIPTION
# Description
This issue was causing a 404 screen to appear when trying to navigate back to the mini app from the external webview if you passed a fragment to the webview

## Links
MINI-4020

# Checklist
- [x] I wrote/updated tests for new/changed code.
- [x] I ran `yarn sdk buildSdk` and `yarn bridge buildBridge` without issues.
- [x] I ran `yarn sample prettify` and `yarn sample build` without issues.
