### PR TITLE
Improvement for value update in custom events

### DIFF
--- a/js-miniapp-bridge/src/common-bridge.ts
+++ b/js-miniapp-bridge/src/common-bridge.ts
@@ -121,13 +121,17 @@ export class MiniAppBridge {
    * @param  {[String]} value Additional message sent from the native on invoking for the eventType
    */
   execCustomEventsCallback(eventType: string, value: string) {
+    let event = new CustomEvent(eventType, { detail: value });
     let queueObj = mabCustomEventQueue.filter(
-      customEvent => customEvent.type === eventType
+      customEvent => customEvent === event
     )[0];
     if (!queueObj) {
-      queueObj = new CustomEvent(eventType, { detail: value });
+      if(eventType === event.type){
+          removeFromEventQueue(event);
+      }
+      queueObj = event;
       mabCustomEventQueue.unshift(queueObj);
-    }
+    } 
     this.executor.execEvents(queueObj);
   }
 
@@ -515,6 +519,15 @@ function removeFromMessageQueue(queueObj) {
   const messageObjIndex = mabMessageQueue.indexOf(queueObj);
   if (messageObjIndex !== -1) {
     mabMessageQueue.splice(messageObjIndex, 1);
+  }
+}
+
+function removeFromEventQueue(queueObj) {
+  const eventObjIndex = mabCustomEventQueue.indexOf(
+    mabCustomEventQueue.filter(customEvent => customEvent.type === queueObj.type)[0]
+  );
+  if (eventObjIndex !== -1) {
+    mabCustomEventQueue.splice(eventObjIndex, 1);
   }
 }
 


### PR DESCRIPTION
# Description
As there is no way to update the detail read only property of a custom event so to update the value of the same event type
first removed the event from the queue and then add a new one with the same event type.

## Links

# Checklist
- [ ] I wrote/updated tests for new/changed code.
- [x] I ran `yarn sdk buildSdk` and `yarn bridge buildBridge` without issues.
- [x] I ran `yarn sample prettify` and `yarn sample build` without issues.
