### PR TITLE
Default permission state change

### DIFF
--- a/js-miniapp-sample/src/pages/file-download.js
+++ b/js-miniapp-sample/src/pages/file-download.js
@@ -62,7 +62,7 @@ type FileDownloadProps = {
 
 const FileDownload = (props: FileDownloadProps) => {
   const classes = useStyles();
-  let [isPermissionGranted, setIsPermissionGranted] = useState(false);
+  let [isPermissionGranted, setIsPermissionGranted] = useState(true);
 
   function requestDownloadAttachmentPermission(url, fileName) {
     const permissionsList = [


### PR DESCRIPTION
# Description
Default permission state changed to true to hide the error message on first load .

## Links
MINI-4291

# Checklist
- [ ] I wrote/updated tests for new/changed code.
- [x] I ran `yarn sdk buildSdk` and `yarn bridge buildBridge` without issues.
- [x] I ran `yarn sample prettify` and `yarn sample build` without issues.
