### PR TITLE
feat: (sample) Add loading icon and timeout on location page

### DIFF
--- a/js-miniapp-sample/src/hooks/useGeoLocation.js
+++ b/js-miniapp-sample/src/hooks/useGeoLocation.js
@@ -5,6 +5,7 @@ import MiniApp from 'js-miniapp-sdk';
 const useGeoLocation = () => {
   const [state, setState] = useState({
     isWatching: false,
+    isLoading: false,
   });
   const watch = () => {
     return MiniApp.requestLocationPermission(
@@ -13,13 +14,25 @@ const useGeoLocation = () => {
       .then(() => {
         setState({
           isWatching: true,
+          isLoading: true,
         });
+
+        const timeout = setTimeout(() => {
+          setState({
+            isWatching: false,
+            isLoading: false,
+            error: 'Timeout',
+          });
+        }, 6000);
 
         navigator.geolocation.getCurrentPosition(
           (pos) => {
+            clearTimeout(timeout);
+
             const { longitude, latitude } = pos.coords;
             setState({
               isWatching: true,
+              isLoading: false,
               location: {
                 latitude,
                 longitude,
@@ -27,6 +40,8 @@ const useGeoLocation = () => {
             });
           },
           (error) => {
+            clearTimeout(timeout);
+
             throw error;
           },
           {
@@ -37,6 +52,7 @@ const useGeoLocation = () => {
       .catch((error) =>
         setState({
           isWatching: false,
+          isLoading: false,
           error,
         })
       );

--- a/js-miniapp-sample/src/pages/web-location.js
+++ b/js-miniapp-sample/src/pages/web-location.js
@@ -4,6 +4,7 @@ import {
   Button,
   CardActions,
   CardContent,
+  CircularProgress,
   makeStyles,
 } from '@material-ui/core';
 import LocationOffIcon from '@material-ui/icons/LocationOff';
@@ -50,6 +51,11 @@ const useStyles = makeStyles((theme) => ({
     color: '#fff !important',
     backgroundColor: `${theme.color.primary} !important`,
   },
+  buttonProgress: {
+    position: 'absolute',
+    top: 'calc(50% - 10px)',
+    left: 'calc(50% - 10px)',
+  },
 }));
 
 const Location = (props: any) => {
@@ -60,6 +66,10 @@ const Location = (props: any) => {
     <GreyCard>
       <CardContent className={classes.content}>
         {state.error && <div>Error: {state.error}</div>}
+
+        {state.isLoading && (
+          <CircularProgress size={20} className={classes.buttonProgress} />
+        )}
 
         {state.location && state.isWatching && (
           <div


### PR DESCRIPTION
# Description
On Android, there is currently a case where the location request can load indefinitely if the Location Services are disabled on the device. Added a timeout to handle this case.

## Links
MALI-898

# Checklist
- [x] I wrote/updated tests for new/changed code.
- [x] I ran `yarn sdk buildSdk` and `yarn bridge buildBridge` without issues.
- [x] I ran `yarn sample prettify` and `yarn sample build` without issues.
