### PR TITLE
feat: (sample) Show XHR download screen on SDK versions below 4.1.0

### DIFF
--- a/js-miniapp-sample/package.json
+++ b/js-miniapp-sample/package.json
@@ -16,7 +16,8 @@
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",
     "@brightcove/react-player-loader": "^1.4.0",
-    "react-copy-to-clipboard": "^5.0.4"
+    "react-copy-to-clipboard": "^5.0.4",
+    "semver": "^7.3.5"
   },
   "scripts": {
     "format": "prettier --config ./prettier.config.js --write 'src/**/*.js'",

--- a/js-miniapp-sample/src/pages/file-download-xhr.js
+++ b/js-miniapp-sample/src/pages/file-download-xhr.js
@@ -1,0 +1,233 @@
+// @flow
+import React, { useState } from 'react';
+
+import {
+  Button,
+  CardContent,
+  CardActions,
+  makeStyles,
+} from '@material-ui/core';
+
+import GreyCard from '../components/GreyCard';
+import { connect } from 'react-redux';
+import { requestCustomPermissions } from '../services/permissions/actions';
+import {
+  CustomPermission,
+  CustomPermissionResult,
+  CustomPermissionName,
+  CustomPermissionStatus,
+} from 'js-miniapp-sdk';
+
+const useStyles = makeStyles((theme) => ({
+  scrollable: {
+    overflowY: 'auto',
+    width: '100%',
+    paddingTop: 20,
+    paddingBottom: 20,
+  },
+  card: {
+    width: '100%',
+    height: 'auto',
+  },
+  actions: {
+    justifyContent: 'center',
+    paddingBottom: 16,
+  },
+  content: {
+    justifyContent: 'center',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    fontSize: 18,
+    color: theme.color.primary,
+    fontWeight: 'bold',
+    paddingBottom: 0,
+  },
+  info: {
+    fontSize: 16,
+    lineBreak: 'anywhere',
+    wordBreak: 'break-all',
+    color: theme.color.primary,
+    marginTop: 0,
+    paddingBottom: 10,
+  },
+}));
+
+type FileDownloadProps = {
+  permissions: CustomPermissionName[],
+  requestPermissions: (
+    permissions: CustomPermission[]
+  ) => Promise<CustomPermissionResult[]>,
+};
+
+const FileDownload = (props: FileDownloadProps) => {
+  const classes = useStyles();
+  let [isPermissionGranted, setIsPermissionGranted] = useState(true);
+
+  function requestDownloadAttachmentPermission(url, fileName) {
+    const permissionsList = [
+      {
+        name: CustomPermissionName.FILE_DOWNLOAD,
+        description: 'We would like to get the permission to download files.',
+      },
+    ];
+
+    props
+      .requestPermissions(permissionsList)
+      .then((permissions) =>
+        permissions
+          .filter(
+            (permission) => permission.status === CustomPermissionStatus.ALLOWED
+          )
+          .map((permission) => permission.name)
+      )
+      .then((permissions) =>
+        Promise.all([
+          hasPermission(CustomPermissionName.FILE_DOWNLOAD, permissions)
+            ? startFileDownload(url, fileName)
+            : setIsPermissionGranted(false),
+        ])
+      )
+      .catch((miniAppError) => {
+        console.error(miniAppError);
+      });
+  }
+
+  function hasPermission(permission, permissionList: ?(string[])) {
+    permissionList = permissionList || props.permissions || [];
+    return permissionList.indexOf(permission) > -1;
+  }
+
+  function onDownloadFile(url, fileName) {
+    requestDownloadAttachmentPermission(url, fileName);
+  }
+
+  function startFileDownload(url, fileName) {
+    setIsPermissionGranted(true);
+    fetch(url, { method: 'GET' })
+      .then((response) => response.blob())
+      .then((blob) => {
+        var fileReader = new window.FileReader();
+        fileReader.readAsDataURL(blob);
+        fileReader.onloadend = () => {
+          var a = document.createElement('a');
+          a.href = fileReader.result;
+          a.download = fileName;
+          document.body && document.body.appendChild(a);
+          a.click();
+          a.remove();
+        };
+      });
+  }
+
+  return (
+    <div className={classes.scrollable}>
+      <GreyCard className={classes.card}>
+        <CardContent className={classes.content}>
+          Download Files via XHR
+        </CardContent>
+        <CardActions className={classes.actions}>
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={() =>
+              // $FlowFixMe
+              onDownloadFile(
+                'https://file-examples-com.github.io/uploads/2017/10/file_example_JPG_100kB.jpg',
+                'sample.jpg'
+              )
+            }
+          >
+            Download Image
+          </Button>
+        </CardActions>
+
+        <CardActions className={classes.actions}>
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={() =>
+              // $FlowFixMe
+              onDownloadFile(
+                'https://file-examples-com.github.io/uploads/2017/02/zip_2MB.zip',
+                'sample.zip'
+              )
+            }
+          >
+            Download ZIP
+          </Button>
+        </CardActions>
+
+        <CardActions className={classes.actions}>
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={() =>
+              // $FlowFixMe
+              onDownloadFile(
+                'https://file-examples-com.github.io/uploads/2017/11/file_example_MP3_700KB.mp3',
+                'sample.mp3'
+              )
+            }
+          >
+            Download MP3
+          </Button>
+        </CardActions>
+
+        <CardActions className={classes.actions}>
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={() =>
+              // $FlowFixMe
+              onDownloadFile(
+                'https://file-examples-com.github.io/uploads/2017/02/file_example_CSV_5000.csv',
+                'sample.csv'
+              )
+            }
+          >
+            Download CSV
+          </Button>
+        </CardActions>
+
+        <CardActions className={classes.actions}>
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={() =>
+              // $FlowFixMe
+              onDownloadFile(
+                'https://file-examples-com.github.io/uploads/2018/04/file_example_MOV_480_700kB.mov',
+                'sample.mov'
+              )
+            }
+          >
+            Download MOV
+          </Button>
+        </CardActions>
+
+        <div className={classes.info}>
+          <p>
+            {!isPermissionGranted && '"FILE_DOWNLOAD" permission not granted.'}
+          </p>
+        </div>
+      </GreyCard>
+    </div>
+  );
+};
+
+const mapStateToProps = (state) => {
+  return {
+    permissions: state.permissions,
+  };
+};
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    requestPermissions: (permissions) =>
+      dispatch(requestCustomPermissions(permissions)),
+  };
+};
+
+export { FileDownload };
+export default connect(mapStateToProps, mapDispatchToProps)(FileDownload);

--- a/js-miniapp-sample/src/routes.js
+++ b/js-miniapp-sample/src/routes.js
@@ -23,6 +23,7 @@ import Ads from './pages/ads';
 import AuthToken from './pages/auth-token';
 import Camera from './pages/camera';
 import FileDownload from './pages/file-download';
+import FileDownloadXhr from './pages/file-download-xhr';
 import FileUploader from './pages/file-upload';
 import GifPage from './pages/gifs';
 import Landing from './pages/landing';
@@ -131,6 +132,14 @@ const appItems = [
     label: 'File Download',
     navLink: '/file_download',
     component: FileDownload,
+    supportedAboveSdkVersion: '4.1.0',
+  },
+  {
+    icon: <CloudDownloadIcon />,
+    label: 'File Download',
+    navLink: '/file_download_xhr',
+    component: FileDownloadXhr,
+    supportedBelowSdkVersion: '4.0.0',
   },
   {
     icon: <AttachFileIcon />,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11959,6 +11959,13 @@ semver@^7.3.2:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.3.5:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
 send@0.17.1:
   version "0.17.1"
   resolved "https://registry.yarnpkg.com/send/-/send-0.17.1.tgz#c1d8b059f7900f7466dd4938bdc44e11ddb376c8"


### PR DESCRIPTION
# Description
SDK versions 4.0.0 and below do not support the new download feature, so we need to show the old XHR download screen instead.

For `file-download-xhr.js` I just copied back the old cold we had for that screen.

## Links
MALI-942

# Checklist
- [x] I wrote/updated tests for new/changed code.
- [x] I ran `yarn sdk buildSdk` and `yarn bridge buildBridge` without issues.
- [x] I ran `yarn sample prettify` and `yarn sample build` without issues.
