### PR TITLE
fix: Allow any key name in DownloadFileHeaders type

### DIFF
--- a/js-miniapp-bridge/src/types/download-file-headers.ts
+++ b/js-miniapp-bridge/src/types/download-file-headers.ts
@@ -1,4 +1,4 @@
 /** DownloadFileHeaders. */
 export interface DownloadFileHeaders {
-  token?: string;
+  [header: string]: string;
 }

--- a/js-miniapp-sdk/src/miniapp.ts
+++ b/js-miniapp-sdk/src/miniapp.ts
@@ -85,7 +85,7 @@ interface MiniAppFeatures {
   downloadFile(
     filename: string,
     url: string,
-    headers: DownloadFileHeaders
+    headers?: DownloadFileHeaders
   ): Promise<string>;
 }
 
@@ -237,7 +237,7 @@ export class MiniApp implements MiniAppFeatures, Ad, Platform {
   downloadFile(
     filename: string,
     url: string,
-    headers: DownloadFileHeaders
+    headers: DownloadFileHeaders = {}
   ): Promise<string> {
     return getBridge().downloadFile(filename, url, headers);
   }


### PR DESCRIPTION
# Description
Allow any key name in DownloadFileHeaders type

# Checklist
- [x] I wrote/updated tests for new/changed code.
- [x] I ran `yarn sdk buildSdk` and `yarn bridge buildBridge` without issues.
- [x] I ran `yarn sample prettify` and `yarn sample build` without issues.
