### PR TITLE
fix: Secure storage ready/error events not received in some cases

### DIFF
--- a/js-miniapp-bridge/src/common-bridge.ts
+++ b/js-miniapp-bridge/src/common-bridge.ts
@@ -18,12 +18,13 @@ import { Points } from './types/points';
 import { Reward } from './types/response-types';
 import { ScreenOrientation } from './types/screen';
 import {
+  MiniAppSecureStorageEvents,
   MiniAppSecureStorageKeyValues,
   MiniAppSecureStorageSize,
 } from './types/secure-storage';
 import { ShareInfoType } from './types/share-info';
 import { AccessTokenData, NativeTokenData } from './types/token-data';
-import { parseMiniAppError } from './types/error-types';
+import { MiniAppError, parseMiniAppError } from './types/error-types';
 
 /** @internal */
 const mabMessageQueue: Callback[] = [];
@@ -71,10 +72,22 @@ export interface PlatformExecutor {
 export class MiniAppBridge {
   executor: PlatformExecutor;
   platform: string;
+  isSecureStorageReady = false;
+  secureStorageLoadError: MiniAppError | null = null;
 
   constructor(executor: PlatformExecutor) {
     this.executor = executor;
     this.platform = executor.getPlatform();
+
+    window.addEventListener(
+      MiniAppSecureStorageEvents.onReady,
+      () => (this.isSecureStorageReady = true)
+    );
+    window.addEventListener(
+      MiniAppSecureStorageEvents.onLoadError,
+      (e: CustomEvent) =>
+        (this.secureStorageLoadError = parseMiniAppError(e.detail.message))
+    );
   }
 
   /**

--- a/js-miniapp-bridge/src/index.ts
+++ b/js-miniapp-bridge/src/index.ts
@@ -41,6 +41,7 @@ import {
 import {
   MiniAppSecureStorageKeyValues,
   MiniAppSecureStorageSize,
+  MiniAppSecureStorageEvents,
 } from './types/secure-storage';
 
 export {
@@ -76,4 +77,5 @@ export {
   SecureStorageBusyError,
   SecureStorageUnavailableError,
   SecureStorageIOError,
+  MiniAppSecureStorageEvents,
 };

--- a/js-miniapp-bridge/src/types/secure-storage.ts
+++ b/js-miniapp-bridge/src/types/secure-storage.ts
@@ -11,3 +11,8 @@ export type MiniAppSecureStorageSize = {
   used: number;
   max: number;
 };
+
+export enum MiniAppSecureStorageEvents {
+  onReady = 'miniappsecurestorageready',
+  onLoadError = 'miniappsecurestorageloaderror',
+}

--- a/js-miniapp-bridge/test/test.spec.ts
+++ b/js-miniapp-bridge/test/test.spec.ts
@@ -22,7 +22,9 @@ import {
 } from '../src';
 
 /* tslint:disable:no-any */
-const window: any = {};
+const window: any = {
+  addEventListener: sinon.stub(),
+};
 (global as any).window = window;
 
 const sandbox = sinon.createSandbox();

--- a/js-miniapp-sample/src/pages/landing.js
+++ b/js-miniapp-sample/src/pages/landing.js
@@ -17,6 +17,7 @@ type LandingProps = {
   infoError: string,
   getHostInfo: Function,
   onSecureStorageReady: Function,
+  secureStorageStatus: string,
 };
 
 const useStyles = makeStyles((theme) => ({
@@ -83,6 +84,9 @@ const Landing = (props: LandingProps) => {
         <p className={classes.info}>
           URL Fragment: {window.location.hash || 'None'}
         </p>
+        <p className={classes.info}>
+          Secure Storage Status: {props.secureStorageStatus}
+        </p>
       </CardContent>
     </GreyCard>
   );
@@ -111,6 +115,10 @@ const mapStateToProps = (state, props) => {
     sdkVersion: state.info.sdkVersion,
     hostLocale: state.info.hostLocale,
     infoError: state.info.infoError,
+    secureStorageStatus:
+      (state.secureStorageStatus.isReady && 'Ready') ||
+      state.secureStorageStatus.error ||
+      'Not Ready',
   };
 };
 

--- a/js-miniapp-sample/src/services/landing/actions.js
+++ b/js-miniapp-sample/src/services/landing/actions.js
@@ -1,14 +1,14 @@
+import MiniApp, {HostEnvironmentInfo, MiniAppError} from 'js-miniapp-sdk';
+
 import {
   REQUEST_HOST_ENVIRONMENT_INFO_SUCCESS,
   REQUEST_HOST_ENVIRONMENT_INFO_ERROR,
   ON_SECURE_STORAGE_READY_SUCCESS,
   ON_SECURE_STORAGE_READY_FAILURE,
 } from './types';
-import MiniApp from 'js-miniapp-sdk';
-import { HostEnvironmentInfo } from 'js-miniapp-sdk';
 
 type RequestHostInfoSuccessAction = { type: String, info: HostEnvironmentInfo };
-type OnStorageReadySuccessAction = { type: string };
+type OnStorageReadySuccessAction = { type: string, error?: MiniAppError };
 
 const setHostEnvironmentInfo = (): Function => {
   return (dispatch) => {
@@ -30,23 +30,24 @@ const setHostEnvironmentInfo = (): Function => {
 
 const onSecureStorageReady = (): Function => {
   return (dispatch) => {
-    return MiniApp.secureStorageService
-      .onSecureStorageReady()
-      .then(() => {
+    return new Promise((resolve) => {
+      MiniApp.secureStorageService.onReady(() => {
         console.log('onSecureStorageReady SuccessAction: ');
         dispatch({
           type: ON_SECURE_STORAGE_READY_SUCCESS,
         });
-        return Promise.resolve('');
-      })
-      .catch((error) => {
+        return resolve();
+      });
+
+      MiniApp.secureStorageService.onLoadError((error) => {
         console.log('onSecureStorageReady Error: ', error);
         dispatch({
           type: ON_SECURE_STORAGE_READY_FAILURE,
-          error,
+          error: error,
         });
-        throw error;
+        return resolve(error);
       });
+    });
   };
 };
 

--- a/js-miniapp-sample/src/services/landing/reducers.js
+++ b/js-miniapp-sample/src/services/landing/reducers.js
@@ -6,6 +6,7 @@ import { HostEnvironmentInfo } from 'js-miniapp-sdk';
 import {
   REQUEST_HOST_ENVIRONMENT_INFO_SUCCESS,
   ON_SECURE_STORAGE_READY_SUCCESS,
+  ON_SECURE_STORAGE_READY_FAILURE,
 } from './types';
 
 const defaultInfo = {};
@@ -22,16 +23,28 @@ const HostEnvironmentInfoReducer = (
 };
 
 const defaultStorageStatusItem = null;
-const onSecureStorageStatusReducer = (
+const SecureStorageStatusReducer = (
   state: ?string = defaultStorageStatusItem,
   action: OnStorageReadySuccessAction
-): ?string => {
+) => {
   switch (action.type) {
     case ON_SECURE_STORAGE_READY_SUCCESS:
-      return action.type;
+      return {
+        isReady: true,
+        error: null,
+      };
+    case ON_SECURE_STORAGE_READY_FAILURE:
+      return {
+        isReady: false,
+        error: action.error,
+      };
     default:
-      return state;
+      return {
+        isReady: false,
+        error: null,
+        ...state,
+      };
   }
 };
 
-export { HostEnvironmentInfoReducer, onSecureStorageStatusReducer };
+export { HostEnvironmentInfoReducer, SecureStorageStatusReducer };

--- a/js-miniapp-sample/src/services/reducers.js
+++ b/js-miniapp-sample/src/services/reducers.js
@@ -5,7 +5,10 @@ import HomeStateReducer from './home/reducers';
 import { grantedPermissionsReducer } from './permissions/reducers';
 import userReducer from './user/reducers';
 import { UUIDReducer } from './uuid/reducers';
-import { HostEnvironmentInfoReducer } from './landing/reducers';
+import {
+  HostEnvironmentInfoReducer,
+  SecureStorageStatusReducer,
+} from './landing/reducers';
 import { FileDownloadReducer } from './filedownload/reducers';
 import storageReducer from './secure-storage/reducers';
 
@@ -18,4 +21,5 @@ export default combineReducers({
   info: HostEnvironmentInfoReducer,
   file: FileDownloadReducer,
   secureStorage: storageReducer,
+  secureStorageStatus: SecureStorageStatusReducer,
 });

--- a/js-miniapp-sdk/src/event-types/index.ts
+++ b/js-miniapp-sdk/src/event-types/index.ts
@@ -5,8 +5,6 @@ export enum MiniAppEvents {
   EXTERNAL_WEBVIEW_CLOSE = 'miniappwebviewclosed',
   PAUSE = 'miniapppause',
   RESUME = 'miniappresume',
-  SECURE_STORAGE_READY = 'miniappsecurestorageready',
-  SECURE_STORAGE_FAILED = 'miniappsecurestorageloaderror',
 }
 
 export enum MiniAppKeyboardEvents {

--- a/js-miniapp-sdk/src/index.ts
+++ b/js-miniapp-sdk/src/index.ts
@@ -31,6 +31,7 @@ import {
   SecureStorageBusyError,
   SecureStorageUnavailableError,
   SecureStorageIOError,
+  MiniAppSecureStorageEvents,
 } from '../../js-miniapp-bridge/src';
 
 import { MiniApp } from './miniapp';
@@ -69,4 +70,5 @@ export {
   SecureStorageBusyError,
   SecureStorageUnavailableError,
   SecureStorageIOError,
+  MiniAppSecureStorageEvents,
 };


### PR DESCRIPTION
# Description
The ready/error events are sent very early when the mini app starts, so the mini app sometimes calls the event listener after the event has already been received. To handle this case, I added a variable in the bridge to cache the state. Also changed the SDK interfaces to accept callback functions instead of Promises

# Checklist
- [x] I have completed all steps in the [Contribution Checklist](../.github/CONTRIBUTING.md#checklist)
