### PR TITLE
[MALI-6198] [JS Sample App] Unable to download ".zip" file from Sample app

### DIFF
--- a/js-miniapp-sample/src/pages/file-download.js
+++ b/js-miniapp-sample/src/pages/file-download.js
@@ -204,7 +204,7 @@ const FileDownload = (props: FileDownloadProps) => {
 
         {renderButton('Download ZIP', 'button-download-zip', () => {
           handleDownloadClick(
-            'https://file-examples.com/wp-content/uploads/2017/02/zip_2MB.zip',
+            'https://file-examples.com/wp-content/storage/2017/02/zip_2MB.zip',
             'sample.zip'
           );
         })}


### PR DESCRIPTION
# Description
Issue: When downloading sample.zip file, An error message is seen "not found; Failed to download the mini app."
cause: The url for the sample.zip file was invalid hence the issue.
Fix: Updating the sample.zip file download URL in the JS-Sample app file-download.js file.

## Links
[MALI-6198](https://jira.rakuten-it.com/jira/browse/MALI-6198)

# Checklist
- [x] I have completed all steps in the [Contribution Checklist](../blob/master.github/CONTRIBUTING.md#checklist)
